### PR TITLE
Feature - 로그아웃, 회원탈퇴 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/com/adregamdi/core/config/WebClientConfig.java
+++ b/src/main/java/com/adregamdi/core/config/WebClientConfig.java
@@ -1,0 +1,15 @@
+package com.adregamdi.core.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder()
+                .build();
+    }
+}

--- a/src/main/java/com/adregamdi/member/application/MemberService.java
+++ b/src/main/java/com/adregamdi/member/application/MemberService.java
@@ -1,11 +1,26 @@
 package com.adregamdi.member.application;
 
+import com.adregamdi.member.domain.Member;
+import com.adregamdi.member.exception.MemberException.MemberNotFoundException;
+import com.adregamdi.member.infrastructure.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class MemberService {
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void logout(final String memberId) {
+        Member member = memberRepository.findByIdAndMemberStatus(UUID.fromString(memberId), true)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+
+        member.updateRefreshTokenStatus(false);
+    }
 }

--- a/src/main/java/com/adregamdi/member/application/MemberService.java
+++ b/src/main/java/com/adregamdi/member/application/MemberService.java
@@ -2,13 +2,21 @@ package com.adregamdi.member.application;
 
 import com.adregamdi.member.domain.Member;
 import com.adregamdi.member.domain.Role;
+import com.adregamdi.member.domain.SocialType;
 import com.adregamdi.member.exception.MemberException.MemberNotFoundException;
 import com.adregamdi.member.infrastructure.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -16,6 +24,7 @@ import java.util.UUID;
 @Service
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final WebClient webClient;
 
     @Transactional
     public void logout(final String memberId) {
@@ -33,5 +42,78 @@ public class MemberService {
         member.updateAuthorization(Role.GUEST);
         member.updateMemberStatus(false);
         member.updateRefreshTokenStatus(false);
+    }
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    @Transactional
+    public void leave() {
+        LocalDateTime date = LocalDateTime.now().minusDays(30);
+        List<Member> members = memberRepository.findByMemberStatusAndUpdatedAt(date)
+                .orElseThrow(MemberNotFoundException::new);
+
+        for (Member member : members) {
+            // 회원과 관련된 데이터 삭제
+            deleteData(member.getId());
+
+            // 소셜 연결 끊기
+            unlink(member.getSocialType(), member.getSocialId(), member.getSocialAccessToken());
+        }
+
+        // 회원 물리 삭제
+        memberRepository.deleteByMemberStatusAndUpdatedAt(date);
+    }
+
+    private void deleteData(final UUID memberId) {
+
+    }
+
+    /**
+     * [연결 끊기 메서드]
+     */
+    private void unlink(
+            final SocialType socialType,
+            final String memberId,
+            final String socialAccessToken) {
+        if (("KAKAO").equals(String.valueOf(socialType))) {
+            unlinkKakao(memberId, socialAccessToken).block();
+        }
+        if (("GOOGLE").equals(String.valueOf(socialType))) {
+            unlinkGoogle(socialAccessToken).block();
+        }
+        throw new RuntimeException();
+    }
+
+    /**
+     * [카카오 연결 끊기]
+     */
+    private Mono<String> unlinkKakao(
+            final String memberId,
+            final String accessToken
+    ) {
+        String url = "https://kapi.kakao.com/v1/user/unlink";
+
+        return webClient.post()
+                .uri(url)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .bodyValue("target_id_type=user_id&target_id=" + memberId)
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+
+    /**
+     * [구글 연결 끊기]
+     */
+    private Mono<String> unlinkGoogle(final String accessToken) {
+        String url = "https://accounts.google.com/o/oauth2/revoke";
+
+        return webClient
+                .post()
+                .uri(uriBuilder -> uriBuilder
+                        .path(url)
+                        .queryParam("token", accessToken)
+                        .build())
+                .retrieve()
+                .bodyToMono(String.class);
     }
 }

--- a/src/main/java/com/adregamdi/member/application/MemberService.java
+++ b/src/main/java/com/adregamdi/member/application/MemberService.java
@@ -1,6 +1,7 @@
 package com.adregamdi.member.application;
 
 import com.adregamdi.member.domain.Member;
+import com.adregamdi.member.domain.Role;
 import com.adregamdi.member.exception.MemberException.MemberNotFoundException;
 import com.adregamdi.member.infrastructure.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,16 @@ public class MemberService {
         Member member = memberRepository.findByIdAndMemberStatus(UUID.fromString(memberId), true)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
 
+        member.updateRefreshTokenStatus(false);
+    }
+
+    @Transactional
+    public void delete(final String memberId) {
+        Member member = memberRepository.findByIdAndMemberStatus(UUID.fromString(memberId), true)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+
+        member.updateAuthorization(Role.GUEST);
+        member.updateMemberStatus(false);
         member.updateRefreshTokenStatus(false);
     }
 }

--- a/src/main/java/com/adregamdi/member/application/MemberService.java
+++ b/src/main/java/com/adregamdi/member/application/MemberService.java
@@ -67,9 +67,6 @@ public class MemberService {
 
     }
 
-    /**
-     * [연결 끊기 메서드]
-     */
     private void unlink(
             final SocialType socialType,
             final String memberId,

--- a/src/main/java/com/adregamdi/member/application/MemberService.java
+++ b/src/main/java/com/adregamdi/member/application/MemberService.java
@@ -1,0 +1,11 @@
+package com.adregamdi.member.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+}

--- a/src/main/java/com/adregamdi/member/domain/Member.java
+++ b/src/main/java/com/adregamdi/member/domain/Member.java
@@ -65,4 +65,13 @@ public class Member {
     public void updateRefreshTokenStatus(Boolean status) {
         this.refreshTokenStatus = status;
     }
+
+    public void updateAuthorization(Role role) {
+        this.role = role;
+    }
+
+    public void updateMemberStatus(Boolean status) {
+        this.memberStatus = status;
+    }
+
 }

--- a/src/main/java/com/adregamdi/member/domain/Member.java
+++ b/src/main/java/com/adregamdi/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.adregamdi.member.domain;
 
+import com.adregamdi.core.entity.BaseTime;
 import com.adregamdi.core.oauth2.dto.SignUpDTO;
 import jakarta.persistence.*;
 import lombok.*;
@@ -12,7 +13,7 @@ import java.util.UUID;
 @Builder
 @Entity
 @Table(name = "tbl_member")
-public class Member {
+public class Member extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;

--- a/src/main/java/com/adregamdi/member/infrastructure/MemberRepository.java
+++ b/src/main/java/com/adregamdi/member/infrastructure/MemberRepository.java
@@ -3,7 +3,12 @@ package com.adregamdi.member.infrastructure;
 import com.adregamdi.member.domain.Member;
 import com.adregamdi.member.domain.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,4 +18,20 @@ public interface MemberRepository extends JpaRepository<Member, UUID> {
     Optional<Member> findByIdAndMemberStatus(UUID memberId, boolean memberStatus);
 
     Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String id);
+
+    @Query("""
+            SELECT m
+            FROM Member m
+            WHERE m.memberStatus= false
+            AND m.updatedAt <= :date
+            """)
+    Optional<List<Member>> findByMemberStatusAndUpdatedAt(@Param("date") final LocalDateTime date);
+
+    @Modifying
+    @Query("""
+            DELETE FROM Member m
+            WHERE m.memberStatus= false
+            AND m.updatedAt < :date
+            """)
+    void deleteByMemberStatusAndUpdatedAt(@Param("date") final LocalDateTime date);
 }

--- a/src/main/java/com/adregamdi/member/presentation/MemberController.java
+++ b/src/main/java/com/adregamdi/member/presentation/MemberController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,6 +26,16 @@ public class MemberController {
         return ResponseEntity.ok()
                 .body(ApiResponse.<Void>builder()
                         .statusCode(HttpStatus.OK)
+                        .build());
+    }
+
+    @DeleteMapping("/leave")
+    @MemberAuthorize
+    public ResponseEntity<ApiResponse<Void>> delete(@AuthenticationPrincipal final UserDetails userDetails) {
+        memberService.delete(userDetails.getUsername());
+        return ResponseEntity.ok()
+                .body(ApiResponse.<Void>builder()
+                        .statusCode(HttpStatus.NO_CONTENT)
                         .build());
     }
 }

--- a/src/main/java/com/adregamdi/member/presentation/MemberController.java
+++ b/src/main/java/com/adregamdi/member/presentation/MemberController.java
@@ -1,0 +1,11 @@
+package com.adregamdi.member.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/member")
+@RestController
+public class MemberController {
+}

--- a/src/main/java/com/adregamdi/member/presentation/MemberController.java
+++ b/src/main/java/com/adregamdi/member/presentation/MemberController.java
@@ -1,6 +1,14 @@
 package com.adregamdi.member.presentation;
 
+import com.adregamdi.core.annotation.MemberAuthorize;
+import com.adregamdi.core.handler.ApiResponse;
+import com.adregamdi.member.application.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,4 +16,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/member")
 @RestController
 public class MemberController {
+    private final MemberService memberService;
+
+    @PostMapping("/logout")
+    @MemberAuthorize
+    public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal final UserDetails userDetails) {
+        memberService.logout(userDetails.getUsername());
+        return ResponseEntity.ok()
+                .body(ApiResponse.<Void>builder()
+                        .statusCode(HttpStatus.OK)
+                        .build());
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closed #15 

## ✨ 과제 내용
로그아웃 구현
- 토큰 상태 필드로 관리

회원탈퇴 구현
- 30일 소프트 삭제
  - 해당 회원과 관련된 엔티티 삭제
- 30일 후 물리 삭제
- 각 소셜 별 연결 끊기

기타
- 외부 api 통신을 위한 webflux 의존성 추가
