### PR TITLE
Feature - QueryDSL 세팅, 알림 관련 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.5'
 }
 
-group = 'com'
+group = 'com.adregamdi'
 version = '0.0.1-SNAPSHOT'
 jar.enabled = false
 
@@ -32,6 +32,19 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    implementation "com.querydsl:querydsl-core"
+    implementation "com.querydsl:querydsl-collections"
+
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+
+    // java.lang.NoClassDefFoundError (javax.annotation.Generated) 에러 대응 코드
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
+    // java.lang.NoClassDefFoundError (javax.annotation.Entity) 에러 대응 코드
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     annotationProcessor 'org.projectlombok:lombok'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -44,4 +57,22 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+///// Querydsl 빌드 옵션 (옵셔널)
+def generated = 'src/main/generated'
+
+///// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+///// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
+///// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-aop'

--- a/src/main/generated/com/adregamdi/core/entity/QBaseTime.java
+++ b/src/main/generated/com/adregamdi/core/entity/QBaseTime.java
@@ -1,0 +1,39 @@
+package com.adregamdi.core.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseTime is a Querydsl query type for BaseTime
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseTime extends EntityPathBase<BaseTime> {
+
+    private static final long serialVersionUID = 1319452787L;
+
+    public static final QBaseTime baseTime = new QBaseTime("baseTime");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QBaseTime(String variable) {
+        super(BaseTime.class, forVariable(variable));
+    }
+
+    public QBaseTime(Path<? extends BaseTime> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseTime(PathMetadata metadata) {
+        super(BaseTime.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/adregamdi/member/domain/QMember.java
+++ b/src/main/generated/com/adregamdi/member/domain/QMember.java
@@ -1,0 +1,69 @@
+package com.adregamdi.member.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = -1591343991L;
+
+    public static final QMember member = new QMember("member1");
+
+    public final com.adregamdi.core.entity.QBaseTime _super = new com.adregamdi.core.entity.QBaseTime(this);
+
+    public final StringPath age = createString("age");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath email = createString("email");
+
+    public final StringPath gender = createString("gender");
+
+    public final ComparablePath<java.util.UUID> id = createComparable("id", java.util.UUID.class);
+
+    public final BooleanPath memberStatus = createBoolean("memberStatus");
+
+    public final StringPath nickname = createString("nickname");
+
+    public final StringPath password = createString("password");
+
+    public final StringPath refreshToken = createString("refreshToken");
+
+    public final BooleanPath refreshTokenStatus = createBoolean("refreshTokenStatus");
+
+    public final EnumPath<Role> role = createEnum("role", Role.class);
+
+    public final StringPath socialAccessToken = createString("socialAccessToken");
+
+    public final StringPath socialId = createString("socialId");
+
+    public final EnumPath<SocialType> socialType = createEnum("socialType", SocialType.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QMember(String variable) {
+        super(Member.class, forVariable(variable));
+    }
+
+    public QMember(Path<? extends Member> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMember(PathMetadata metadata) {
+        super(Member.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/adregamdi/notification/domain/QNotification.java
+++ b/src/main/generated/com/adregamdi/notification/domain/QNotification.java
@@ -1,0 +1,55 @@
+package com.adregamdi.notification.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QNotification is a Querydsl query type for Notification
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNotification extends EntityPathBase<Notification> {
+
+    private static final long serialVersionUID = 655974571L;
+
+    public static final QNotification notification = new QNotification("notification");
+
+    public final com.adregamdi.core.entity.QBaseTime _super = new com.adregamdi.core.entity.QBaseTime(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isRead = createBoolean("isRead");
+
+    public final ComparablePath<java.util.UUID> memberId = createComparable("memberId", java.util.UUID.class);
+
+    public final EnumPath<NotificationType> type = createEnum("type", NotificationType.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final StringPath uri = createString("uri");
+
+    public QNotification(String variable) {
+        super(Notification.class, forVariable(variable));
+    }
+
+    public QNotification(Path<? extends Notification> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QNotification(PathMetadata metadata) {
+        super(Notification.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/adregamdi/core/config/QueryDSLConfig.java
+++ b/src/main/java/com/adregamdi/core/config/QueryDSLConfig.java
@@ -1,0 +1,19 @@
+package com.adregamdi.core.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class QueryDSLConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/adregamdi/member/application/MemberService.java
+++ b/src/main/java/com/adregamdi/member/application/MemberService.java
@@ -27,6 +27,9 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final WebClient webClient;
 
+    /**
+     * [내 정보 조회]
+     */
     @Transactional
     public GetMyMemberResponse getMyMember(final String username) {
         Member member = memberRepository.findById(UUID.fromString(username))
@@ -35,6 +38,9 @@ public class MemberService {
         return GetMyMemberResponse.from(member);
     }
 
+    /**
+     * [로그아웃]
+     */
     @Transactional
     public void logout(final String memberId) {
         Member member = memberRepository.findByIdAndMemberStatus(UUID.fromString(memberId), true)
@@ -43,6 +49,9 @@ public class MemberService {
         member.updateRefreshTokenStatus(false);
     }
 
+    /**
+     * [소프트 탈퇴]
+     */
     @Transactional
     public void delete(final String memberId) {
         Member member = memberRepository.findByIdAndMemberStatus(UUID.fromString(memberId), true)
@@ -53,6 +62,9 @@ public class MemberService {
         member.updateRefreshTokenStatus(false);
     }
 
+    /**
+     * [완전 탈퇴]
+     */
     @Scheduled(cron = "0 0 0 * * ?")
     @Transactional
     public void leave() {
@@ -76,6 +88,9 @@ public class MemberService {
 
     }
 
+    /**
+     * [연결 끊기]
+     */
     private void unlink(
             final SocialType socialType,
             final String memberId,

--- a/src/main/java/com/adregamdi/member/application/MemberService.java
+++ b/src/main/java/com/adregamdi/member/application/MemberService.java
@@ -67,7 +67,7 @@ public class MemberService {
      */
     @Scheduled(cron = "0 0 0 * * ?")
     @Transactional
-    public void leave() {
+    protected void leave() {
         LocalDateTime date = LocalDateTime.now().minusDays(30);
         List<Member> members = memberRepository.findByMemberStatusAndUpdatedAt(date)
                 .orElseThrow(MemberNotFoundException::new);

--- a/src/main/java/com/adregamdi/member/domain/Member.java
+++ b/src/main/java/com/adregamdi/member/domain/Member.java
@@ -17,7 +17,6 @@ public class Member extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
-
     @Column
     private String nickname; // 닉네임
     @Column

--- a/src/main/java/com/adregamdi/notification/application/NotificationService.java
+++ b/src/main/java/com/adregamdi/notification/application/NotificationService.java
@@ -1,0 +1,70 @@
+package com.adregamdi.notification.application;
+
+import com.adregamdi.notification.domain.Notification;
+import com.adregamdi.notification.dto.NotificationDTO;
+import com.adregamdi.notification.dto.request.UpdateNotificationRequest;
+import com.adregamdi.notification.dto.response.GetNotificationResponse;
+import com.adregamdi.notification.exception.NotificationException.NotificationNotFoundException;
+import com.adregamdi.notification.infrastructure.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+
+    /**
+     * [전체 안 읽은 알림 조회]
+     */
+    @Transactional(readOnly = true)
+    public GetNotificationResponse get(final Long lastId, final String memberId) {
+        List<Notification> notifications = notificationRepository.findByMemberId(UUID.fromString(memberId), LocalDateTime.now().minusDays(31), lastId)
+                .orElseThrow(() -> new NotificationNotFoundException(memberId));
+
+        return GetNotificationResponse.of(
+                countNoReadNotification(notifications),
+                notifications.stream().map(NotificationDTO::from).toList()
+        );
+    }
+
+    /**
+     * [안 읽은 알림 개수 세기]
+     */
+    private int countNoReadNotification(final List<Notification> notifications) {
+        return (int) notifications.stream()
+                .filter(notification -> !notification.isRead())
+                .count();
+    }
+
+    /**
+     * [알림 수정]
+     * 사용자가 알림 읽으면 상태 true 로 변경
+     */
+    @Transactional
+    public void update(final List<UpdateNotificationRequest> requests) {
+        requests.stream()
+                .map(request -> notificationRepository.findById(request.notificationId())
+                        .orElseThrow(() -> new NotificationNotFoundException(request.notificationId())))
+                .forEach(notification -> notification.updateIsRead(true));
+    }
+
+    /**
+     * [알림 삭제]
+     * 30일이 지난 알림들 매일 자정에 삭제
+     */
+    @Scheduled(cron = "0 0 0 * * ?")
+    @Transactional
+    protected void delete() {
+        LocalDateTime date = LocalDateTime.now().minusDays(30);
+        notificationRepository.deleteByCreatedAt(date);
+    }
+}

--- a/src/main/java/com/adregamdi/notification/application/NotificationService.java
+++ b/src/main/java/com/adregamdi/notification/application/NotificationService.java
@@ -23,7 +23,7 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
 
     /**
-     * [전체 안 읽은 알림 조회]
+     * [내 알림 조회]
      */
     @Transactional(readOnly = true)
     public GetNotificationResponse get(final Long lastId, final String memberId) {

--- a/src/main/java/com/adregamdi/notification/domain/Notification.java
+++ b/src/main/java/com/adregamdi/notification/domain/Notification.java
@@ -1,0 +1,19 @@
+package com.adregamdi.notification.domain;
+
+import com.adregamdi.core.entity.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "tbl_notification")
+public class Notification extends BaseTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+}

--- a/src/main/java/com/adregamdi/notification/domain/Notification.java
+++ b/src/main/java/com/adregamdi/notification/domain/Notification.java
@@ -17,5 +17,11 @@ public class Notification extends BaseTime {
     @GeneratedValue(strategy = GenerationType.UUID)
     private Long id;
     @Column
-    private UUID memberId;
+    private UUID memberId; // 회원 id
+    @Column
+    private String content; // 내용
+    @Column
+    private String uri; // 필요 시 리다이렉트 시킬 uri
+    @Column
+    private boolean isRead; // 상태 (T: 읽음, F: 안 읽음)
 }

--- a/src/main/java/com/adregamdi/notification/domain/Notification.java
+++ b/src/main/java/com/adregamdi/notification/domain/Notification.java
@@ -15,5 +15,7 @@ import java.util.UUID;
 public class Notification extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+    private Long id;
+    @Column
+    private UUID memberId;
 }

--- a/src/main/java/com/adregamdi/notification/domain/Notification.java
+++ b/src/main/java/com/adregamdi/notification/domain/Notification.java
@@ -26,7 +26,7 @@ public class Notification extends BaseTime {
     private boolean isRead; // 상태 (T: 읽음, F: 안 읽음)
 
     @Enumerated(EnumType.STRING)
-    private NotificationType type; // 알림 종류 ()
+    private NotificationType type; // 알림 종류 (좋아요, 일정)
 
     public void updateIsRead(final boolean isRead) {
         this.isRead = isRead;

--- a/src/main/java/com/adregamdi/notification/domain/Notification.java
+++ b/src/main/java/com/adregamdi/notification/domain/Notification.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 @Table(name = "tbl_notification")
 public class Notification extends BaseTime {
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Column
     private UUID memberId; // 회원 id

--- a/src/main/java/com/adregamdi/notification/domain/Notification.java
+++ b/src/main/java/com/adregamdi/notification/domain/Notification.java
@@ -24,4 +24,11 @@ public class Notification extends BaseTime {
     private String uri; // 필요 시 리다이렉트 시킬 uri
     @Column
     private boolean isRead; // 상태 (T: 읽음, F: 안 읽음)
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType type; // 알림 종류 ()
+
+    public void updateIsRead(final boolean isRead) {
+        this.isRead = isRead;
+    }
 }

--- a/src/main/java/com/adregamdi/notification/domain/NotificationType.java
+++ b/src/main/java/com/adregamdi/notification/domain/NotificationType.java
@@ -1,0 +1,4 @@
+package com.adregamdi.notification.domain;
+
+public enum NotificationType {
+}

--- a/src/main/java/com/adregamdi/notification/domain/NotificationType.java
+++ b/src/main/java/com/adregamdi/notification/domain/NotificationType.java
@@ -1,4 +1,6 @@
 package com.adregamdi.notification.domain;
 
 public enum NotificationType {
+    LIKE,
+    TRAVEL
 }

--- a/src/main/java/com/adregamdi/notification/dto/NotificationDTO.java
+++ b/src/main/java/com/adregamdi/notification/dto/NotificationDTO.java
@@ -1,0 +1,34 @@
+package com.adregamdi.notification.dto;
+
+import com.adregamdi.notification.domain.Notification;
+import com.adregamdi.notification.domain.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationDTO {
+    private Long id;
+    private String content;
+    private String uri;
+    private NotificationType type;
+    private boolean isRead;
+    private LocalDate createdAt;
+
+    public static NotificationDTO from(final Notification notification) {
+        return NotificationDTO.builder()
+                .id(notification.getId())
+                .content(notification.getContent())
+                .uri(notification.getUri())
+                .type(notification.getType())
+                .isRead(notification.isRead())
+                .createdAt(LocalDate.from(notification.getCreatedAt()))
+                .build();
+    }
+}

--- a/src/main/java/com/adregamdi/notification/dto/request/UpdateNotificationRequest.java
+++ b/src/main/java/com/adregamdi/notification/dto/request/UpdateNotificationRequest.java
@@ -1,0 +1,6 @@
+package com.adregamdi.notification.dto.request;
+
+public record UpdateNotificationRequest(
+        
+) {
+}

--- a/src/main/java/com/adregamdi/notification/dto/request/UpdateNotificationRequest.java
+++ b/src/main/java/com/adregamdi/notification/dto/request/UpdateNotificationRequest.java
@@ -1,6 +1,9 @@
 package com.adregamdi.notification.dto.request;
 
+import jakarta.validation.constraints.Positive;
+
 public record UpdateNotificationRequest(
-        
+        @Positive
+        Long notificationId
 ) {
 }

--- a/src/main/java/com/adregamdi/notification/dto/response/GetNotificationResponse.java
+++ b/src/main/java/com/adregamdi/notification/dto/response/GetNotificationResponse.java
@@ -1,0 +1,6 @@
+package com.adregamdi.notification.dto.response;
+
+public record GetNotificationResponse(
+
+) {
+}

--- a/src/main/java/com/adregamdi/notification/dto/response/GetNotificationResponse.java
+++ b/src/main/java/com/adregamdi/notification/dto/response/GetNotificationResponse.java
@@ -1,6 +1,19 @@
 package com.adregamdi.notification.dto.response;
 
-public record GetNotificationResponse(
+import com.adregamdi.notification.dto.NotificationDTO;
+import lombok.Builder;
 
+import java.util.List;
+
+@Builder
+public record GetNotificationResponse(
+        int noReadElements,
+        List<NotificationDTO> notificationList
 ) {
+    public static GetNotificationResponse of(final int noReadElements, final List<NotificationDTO> notificationList) {
+        return GetNotificationResponse.builder()
+                .noReadElements(noReadElements)
+                .notificationList(notificationList)
+                .build();
+    }
 }

--- a/src/main/java/com/adregamdi/notification/exception/NotificationException.java
+++ b/src/main/java/com/adregamdi/notification/exception/NotificationException.java
@@ -1,0 +1,19 @@
+package com.adregamdi.notification.exception;
+
+public class NotificationException extends RuntimeException {
+
+    public NotificationException(final String message) {
+        super(message);
+    }
+
+    public static class NotificationNotFoundException extends NotificationException {
+
+        public NotificationNotFoundException() {
+            super("알림이 존재하지 않습니다.");
+        }
+
+        public NotificationNotFoundException(final Object object) {
+            super(String.format("알림이 존재하지 않습니다. - request info => %s", object));
+        }
+    }
+}

--- a/src/main/java/com/adregamdi/notification/infrastructure/NotificationCustomRepository.java
+++ b/src/main/java/com/adregamdi/notification/infrastructure/NotificationCustomRepository.java
@@ -1,0 +1,12 @@
+package com.adregamdi.notification.infrastructure;
+
+import com.adregamdi.notification.domain.Notification;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface NotificationCustomRepository {
+    Optional<List<Notification>> findByMemberId(final UUID memberId, final LocalDateTime date, final Long lastId);
+}

--- a/src/main/java/com/adregamdi/notification/infrastructure/NotificationCustomRepositoryImpl.java
+++ b/src/main/java/com/adregamdi/notification/infrastructure/NotificationCustomRepositoryImpl.java
@@ -1,6 +1,8 @@
 package com.adregamdi.notification.infrastructure;
 
 import com.adregamdi.notification.domain.Notification;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -8,6 +10,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import static com.adregamdi.notification.domain.QNotification.notification;
 
 @RequiredArgsConstructor
 @Repository
@@ -25,7 +29,7 @@ public class NotificationCustomRepositoryImpl implements NotificationCustomRepos
                 .select(notification)
                 .from(notification)
                 .where(
-                        notification.member.id.eq(memberId),
+                        notification.memberId.eq(memberId),
                         notification.createdAt.gt(date),
                         toContainsLastId(lastId)
                 )

--- a/src/main/java/com/adregamdi/notification/infrastructure/NotificationCustomRepositoryImpl.java
+++ b/src/main/java/com/adregamdi/notification/infrastructure/NotificationCustomRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.adregamdi.notification.infrastructure;
+
+import com.adregamdi.notification.domain.Notification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Repository
+public class NotificationCustomRepositoryImpl implements NotificationCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<List<Notification>> findByMemberId(
+            final UUID memberId,
+            final LocalDateTime date,
+            final Long lastId
+    ) {
+        List<Notification> notifications = jpaQueryFactory
+                .select(notification)
+                .from(notification)
+                .where(
+                        notification.member.id.eq(memberId),
+                        notification.createdAt.gt(date),
+                        toContainsLastId(lastId)
+                )
+                .orderBy(notification.createdAt.desc())
+                .limit(10)
+                .fetch();
+
+        return Optional.of(notifications);
+    }
+
+    private BooleanExpression toContainsLastId(final Long lastId) {
+        if (lastId == null) {
+            return null;
+        }
+        return notification.id.lt(lastId);
+    }
+}

--- a/src/main/java/com/adregamdi/notification/infrastructure/NotificationRepository.java
+++ b/src/main/java/com/adregamdi/notification/infrastructure/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.adregamdi.notification.infrastructure;
+
+import com.adregamdi.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/adregamdi/notification/infrastructure/NotificationRepository.java
+++ b/src/main/java/com/adregamdi/notification/infrastructure/NotificationRepository.java
@@ -2,6 +2,20 @@ package com.adregamdi.notification.infrastructure;
 
 import com.adregamdi.notification.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface NotificationRepository extends JpaRepository<Notification, Long> {
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationCustomRepository {
+    @Modifying
+    @Query("""
+            DELETE FROM Notification n
+            WHERE n.createdAt< :date
+            """)
+    void deleteByCreatedAt(@Param("date") final LocalDateTime date);
+
+    void deleteByMemberId(UUID id);
 }

--- a/src/main/java/com/adregamdi/notification/presentation/NotificationController.java
+++ b/src/main/java/com/adregamdi/notification/presentation/NotificationController.java
@@ -1,0 +1,11 @@
+package com.adregamdi.notification.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/notification")
+@RestController
+public class NotificationController {
+}

--- a/src/main/java/com/adregamdi/notification/presentation/NotificationController.java
+++ b/src/main/java/com/adregamdi/notification/presentation/NotificationController.java
@@ -1,11 +1,48 @@
 package com.adregamdi.notification.presentation;
 
+import com.adregamdi.core.annotation.MemberAuthorize;
+import com.adregamdi.core.handler.ApiResponse;
+import com.adregamdi.notification.application.NotificationService;
+import com.adregamdi.notification.dto.request.UpdateNotificationRequest;
+import com.adregamdi.notification.dto.response.GetNotificationResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/notification")
 @RestController
 public class NotificationController {
+    private final NotificationService notificationService;
+
+    @GetMapping
+    @MemberAuthorize
+    public ResponseEntity<ApiResponse<GetNotificationResponse>> get(
+            @RequestParam(defaultValue = "", required = false) final Long lastId,
+            @AuthenticationPrincipal final UserDetails userDetails
+    ) {
+        return ResponseEntity.ok()
+                .body(ApiResponse.<GetNotificationResponse>builder()
+                        .statusCode(HttpStatus.OK)
+                        .data(notificationService.get(lastId, userDetails.getUsername()))
+                        .build()
+                );
+    }
+
+    @PatchMapping
+    @MemberAuthorize
+    public ResponseEntity<ApiResponse<Void>> update(@RequestBody @Valid final List<UpdateNotificationRequest> requests) {
+        notificationService.update(requests);
+        return ResponseEntity.ok()
+                .body(ApiResponse.<Void>builder()
+                        .statusCode(HttpStatus.NO_CONTENT)
+                        .build()
+                );
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closed #22 

## ✨ 과제 내용
1. QueryDSL 세팅

2. 알림 기능 구현
- 내 알림 조회
  - 안 읽은 알림 개수도 같이 조회
- 알림 수정
  - 알림 읽으면 읽음 상태로 수정
- 알림 삭제
  - 읽은 후 30일 지난 알림 스케쥴러로 자동 삭제

## 📸 스크린샷(선택)
API 주소는 포스트맨 참고 !!
![image](https://github.com/user-attachments/assets/e4d178f7-83ea-4b4c-bc55-25b1a19742aa)
