### PR TITLE
Refactor - 로그인 기능 수정

### DIFF
--- a/src/main/java/com/adregamdi/core/config/SecurityConfig.java
+++ b/src/main/java/com/adregamdi/core/config/SecurityConfig.java
@@ -31,7 +31,8 @@ public class SecurityConfig {
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
     private final String[] ALLOWED_URLS = {
             "/",
-            "/index.html"
+            "/index.html",
+            "/api/member/login"
     };
 
     @Bean

--- a/src/main/java/com/adregamdi/core/config/SecurityConfig.java
+++ b/src/main/java/com/adregamdi/core/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
     private final String[] ALLOWED_URLS = {
             "/",
             "/index.html",
-            "/api/member/login"
+            "/api/oauth2/login"
     };
 
     @Bean

--- a/src/main/java/com/adregamdi/core/config/SecurityConfig.java
+++ b/src/main/java/com/adregamdi/core/config/SecurityConfig.java
@@ -53,11 +53,11 @@ public class SecurityConfig {
                 .authorizeHttpRequests(request ->
                         request.requestMatchers(ALLOWED_URLS).permitAll()
                                 .anyRequest().authenticated())
-                .oauth2Login(oauth2Login -> oauth2Login
-                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
-                        .successHandler(oAuth2LoginSuccessHandler) // 동의하기 눌렀을 때 핸들러 설정
-                        .failureHandler(oAuth2LoginFailureHandler) // 소셜 로그인 실패 시 핸들러 설정
-                )
+//                .oauth2Login(oauth2Login -> oauth2Login
+//                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+//                        .successHandler(oAuth2LoginSuccessHandler)
+//                        .failureHandler(oAuth2LoginFailureHandler)
+//                )
                 .addFilterAfter(jwtAuthenticationFilter(), LogoutFilter.class)
         ;
 

--- a/src/main/java/com/adregamdi/core/oauth2/dto/ApplePublicKey.java
+++ b/src/main/java/com/adregamdi/core/oauth2/dto/ApplePublicKey.java
@@ -1,4 +1,10 @@
 package com.adregamdi.core.oauth2.dto;
 
-public class ApplePublicKey {
+public record ApplePublicKey(
+        String kty,
+        String kid,
+        String alg,
+        String n,
+        String e
+) {
 }

--- a/src/main/java/com/adregamdi/core/oauth2/dto/LoginRequest.java
+++ b/src/main/java/com/adregamdi/core/oauth2/dto/LoginRequest.java
@@ -1,7 +1,11 @@
 package com.adregamdi.core.oauth2.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record LoginRequest(
+        @NotBlank
         String oauthAccessToken,
+        @NotBlank
         String socialType
 ) {
 }

--- a/src/main/java/com/adregamdi/core/oauth2/dto/LoginRequest.java
+++ b/src/main/java/com/adregamdi/core/oauth2/dto/LoginRequest.java
@@ -1,0 +1,7 @@
+package com.adregamdi.core.oauth2.dto;
+
+public record LoginRequest(
+        String oauthAccessToken,
+        String socialType
+) {
+}

--- a/src/main/java/com/adregamdi/core/oauth2/dto/LoginResponse.java
+++ b/src/main/java/com/adregamdi/core/oauth2/dto/LoginResponse.java
@@ -1,4 +1,7 @@
 package com.adregamdi.core.oauth2.dto;
 
-public record LoginResponse() {
+public record LoginResponse(
+        String accessToken,
+        String refreshToken
+) {
 }

--- a/src/main/java/com/adregamdi/core/oauth2/dto/LoginResponse.java
+++ b/src/main/java/com/adregamdi/core/oauth2/dto/LoginResponse.java
@@ -1,0 +1,4 @@
+package com.adregamdi.core.oauth2.dto;
+
+public record LoginResponse() {
+}

--- a/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
+++ b/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
@@ -1,6 +1,7 @@
 package com.adregamdi.core.oauth2.presentation;
 
 import com.adregamdi.core.handler.ApiResponse;
+import com.adregamdi.core.oauth2.dto.LoginResponse;
 import com.adregamdi.core.oauth2.service.OAuth2Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,11 +18,11 @@ public class OAuth2Controller {
     private final OAuth2Service oAuth2Service;
 
     @GetMapping("/login")
-    public ResponseEntity<ApiResponse<Void>> login(OAuth2AuthenticationToken token) {
-        oAuth2Service.login(token);
+    public ResponseEntity<ApiResponse<LoginResponse>> login(OAuth2AuthenticationToken token) {
         return ResponseEntity.ok()
-                .body(ApiResponse.<Void>builder()
+                .body(ApiResponse.<LoginResponse>builder()
                         .statusCode(HttpStatus.OK)
+                        .data(oAuth2Service.login(token))
                         .build());
     }
 }

--- a/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
+++ b/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
@@ -8,7 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class OAuth2Controller {
     private final OAuth2Service oAuth2Service;
 
-    @GetMapping("/login")
+    @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid final LoginRequest request) {
         return ResponseEntity.ok()
                 .body(ApiResponse.<LoginResponse>builder()

--- a/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
+++ b/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
@@ -6,7 +6,6 @@ import com.adregamdi.core.oauth2.service.OAuth2Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,11 +17,11 @@ public class OAuth2Controller {
     private final OAuth2Service oAuth2Service;
 
     @GetMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponse>> login(OAuth2AuthenticationToken token) {
+    public ResponseEntity<ApiResponse<LoginResponse>> login(String oauthAccessToken) {
         return ResponseEntity.ok()
                 .body(ApiResponse.<LoginResponse>builder()
                         .statusCode(HttpStatus.OK)
-                        .data(oAuth2Service.login(token))
+                        .data(oAuth2Service.login(oauthAccessToken))
                         .build());
     }
 }

--- a/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
+++ b/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/oauth2/kakao")
+@RequestMapping("/api/oauth2")
 @RestController
 public class OAuth2Controller {
     private final OAuth2Service oAuth2Service;

--- a/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
+++ b/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
@@ -4,6 +4,7 @@ import com.adregamdi.core.handler.ApiResponse;
 import com.adregamdi.core.oauth2.dto.LoginRequest;
 import com.adregamdi.core.oauth2.dto.LoginResponse;
 import com.adregamdi.core.oauth2.service.OAuth2Service;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +20,7 @@ public class OAuth2Controller {
     private final OAuth2Service oAuth2Service;
 
     @GetMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody LoginRequest request) {
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid final LoginRequest request) {
         return ResponseEntity.ok()
                 .body(ApiResponse.<LoginResponse>builder()
                         .statusCode(HttpStatus.OK)

--- a/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
+++ b/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
@@ -1,0 +1,26 @@
+package com.adregamdi.core.oauth2.presentation;
+
+import com.adregamdi.core.handler.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/oauth2/kakao")
+@RestController
+public class OAuth2Controller {
+    @GetMapping("/login")
+    public ResponseEntity<ApiResponse<Void>> login(@RequestHeader("") String token) {
+
+
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.<Void>builder()
+                        .statusCode(HttpStatus.OK)
+                        .build());
+    }
+}

--- a/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
+++ b/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
@@ -1,23 +1,28 @@
 package com.adregamdi.core.oauth2.presentation;
 
 import com.adregamdi.core.handler.ApiResponse;
+import com.adregamdi.core.jwt.service.JwtService;
+import com.adregamdi.core.oauth2.service.OAuth2Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @RequiredArgsConstructor
 @RequestMapping("/api/oauth2/kakao")
 @RestController
 public class OAuth2Controller {
+    private final OAuth2Service oAuth2Service;
+
     @GetMapping("/login")
-    public ResponseEntity<ApiResponse<Void>> login(@RequestHeader("") String token) {
-
-
-
+    public ResponseEntity<ApiResponse<Void>> login(OAuth2AuthenticationToken token) {
+        oAuth2Service.login(token);
         return ResponseEntity.ok()
                 .body(ApiResponse.<Void>builder()
                         .statusCode(HttpStatus.OK)

--- a/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
+++ b/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
@@ -1,18 +1,14 @@
 package com.adregamdi.core.oauth2.presentation;
 
 import com.adregamdi.core.handler.ApiResponse;
-import com.adregamdi.core.jwt.service.JwtService;
 import com.adregamdi.core.oauth2.service.OAuth2Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Map;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/oauth2/kakao")

--- a/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
+++ b/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
@@ -1,12 +1,14 @@
 package com.adregamdi.core.oauth2.presentation;
 
 import com.adregamdi.core.handler.ApiResponse;
+import com.adregamdi.core.oauth2.dto.LoginRequest;
 import com.adregamdi.core.oauth2.dto.LoginResponse;
 import com.adregamdi.core.oauth2.service.OAuth2Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,11 +19,11 @@ public class OAuth2Controller {
     private final OAuth2Service oAuth2Service;
 
     @GetMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponse>> login(String oauthAccessToken) {
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody LoginRequest request) {
         return ResponseEntity.ok()
                 .body(ApiResponse.<LoginResponse>builder()
                         .statusCode(HttpStatus.OK)
-                        .data(oAuth2Service.login(oauthAccessToken))
+                        .data(oAuth2Service.login(request))
                         .build());
     }
 }

--- a/src/main/java/com/adregamdi/core/oauth2/service/OAuth2Service.java
+++ b/src/main/java/com/adregamdi/core/oauth2/service/OAuth2Service.java
@@ -4,7 +4,6 @@ import com.adregamdi.core.jwt.service.JwtService;
 import com.adregamdi.core.oauth2.dto.LoginResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -13,7 +12,7 @@ import org.springframework.stereotype.Service;
 public class OAuth2Service {
     private final JwtService jwtService;
 
-    public LoginResponse login(OAuth2AuthenticationToken token) {
+    public LoginResponse login(String oauthAccessToken) {
         return null;
     }
 }

--- a/src/main/java/com/adregamdi/core/oauth2/service/OAuth2Service.java
+++ b/src/main/java/com/adregamdi/core/oauth2/service/OAuth2Service.java
@@ -1,18 +1,81 @@
 package com.adregamdi.core.oauth2.service;
 
 import com.adregamdi.core.jwt.service.JwtService;
+import com.adregamdi.core.oauth2.dto.LoginRequest;
 import com.adregamdi.core.oauth2.dto.LoginResponse;
+import com.adregamdi.core.oauth2.dto.OAuth2Attributes;
+import com.adregamdi.member.domain.Member;
+import com.adregamdi.member.domain.SocialType;
+import com.adregamdi.member.infrastructure.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+import java.util.Objects;
+
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class OAuth2Service {
+    private static final String APPLE = "apple";
+    private static final String KAKAO = "kakao";
     private final JwtService jwtService;
+    private final MemberRepository memberRepository;
+    private final WebClient webClient;
 
-    public LoginResponse login(String oauthAccessToken) {
-        return null;
+    @Transactional
+    public LoginResponse login(LoginRequest request) {
+        String userInfoUrl = "https://kapi.kakao.com/v2/user/me";
+
+        Map userInfo = webClient
+                .get()
+                .uri(userInfoUrl)
+                .headers(headers -> headers.setBearerAuth(request.oauthAccessToken()))
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+
+        SocialType socialType = getSocialType("kakao");
+        String userNameAttributeName = "id";
+        OAuth2Attributes extractAttributes = OAuth2Attributes.of(socialType, userNameAttributeName, userInfo);
+
+        Member findMember = getMember(extractAttributes, socialType);
+        findMember.updateSocialAccessToken(request.oauthAccessToken());
+
+        String accessToken = jwtService.createAccessToken(String.valueOf(findMember.getId()), findMember.getRole());
+        String refreshToken = jwtService.createRefreshToken();
+        findMember.updateRefreshToken(refreshToken);
+        findMember.updateRefreshTokenStatus(true);
+
+        return new LoginResponse(accessToken, refreshToken);
+    }
+
+    private SocialType getSocialType(final String registrationId) {
+        if (Objects.equals(APPLE, registrationId)) {
+            return SocialType.APPLE;
+        }
+        if (Objects.equals(KAKAO, registrationId)) {
+            return SocialType.KAKAO;
+        }
+        return SocialType.GOOGLE;
+    }
+
+    private Member getMember(final OAuth2Attributes attributes, final SocialType socialType) {
+        Member findMember = memberRepository.findBySocialTypeAndSocialId(socialType, attributes.getOauth2UserInfo().getId())
+                .orElse(null);
+
+        if (findMember == null) {
+            return saveMember(attributes, socialType);
+        }
+        return findMember;
+    }
+
+    private Member saveMember(final OAuth2Attributes attributes, final SocialType socialType) {
+        Member createdMember = attributes.toEntity(socialType, attributes.getOauth2UserInfo());
+        return memberRepository.save(createdMember);
     }
 }

--- a/src/main/java/com/adregamdi/core/oauth2/service/OAuth2Service.java
+++ b/src/main/java/com/adregamdi/core/oauth2/service/OAuth2Service.java
@@ -1,6 +1,7 @@
 package com.adregamdi.core.oauth2.service;
 
 import com.adregamdi.core.jwt.service.JwtService;
+import com.adregamdi.core.oauth2.dto.LoginResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 public class OAuth2Service {
     private final JwtService jwtService;
 
-    public void login(OAuth2AuthenticationToken token) {
+    public LoginResponse login(OAuth2AuthenticationToken token) {
+        return null;
     }
 }

--- a/src/main/java/com/adregamdi/core/oauth2/service/OAuth2Service.java
+++ b/src/main/java/com/adregamdi/core/oauth2/service/OAuth2Service.java
@@ -1,0 +1,17 @@
+package com.adregamdi.core.oauth2.service;
+
+import com.adregamdi.core.jwt.service.JwtService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class OAuth2Service {
+    private final JwtService jwtService;
+
+    public void login(OAuth2AuthenticationToken token) {
+    }
+}

--- a/src/main/java/com/adregamdi/member/application/MemberService.java
+++ b/src/main/java/com/adregamdi/member/application/MemberService.java
@@ -27,6 +27,10 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final WebClient webClient;
 
+    @Transactional
+    public void login() {
+    }
+
     /**
      * [내 정보 조회]
      */

--- a/src/main/java/com/adregamdi/member/application/MemberService.java
+++ b/src/main/java/com/adregamdi/member/application/MemberService.java
@@ -1,5 +1,6 @@
 package com.adregamdi.member.application;
 
+import com.adregamdi.core.jwt.service.JwtService;
 import com.adregamdi.member.domain.Member;
 import com.adregamdi.member.domain.Role;
 import com.adregamdi.member.domain.SocialType;
@@ -26,10 +27,6 @@ import java.util.UUID;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final WebClient webClient;
-
-    @Transactional
-    public void login() {
-    }
 
     /**
      * [내 정보 조회]

--- a/src/main/java/com/adregamdi/member/presentation/MemberController.java
+++ b/src/main/java/com/adregamdi/member/presentation/MemberController.java
@@ -17,15 +17,6 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
     private final MemberService memberService;
 
-    @GetMapping("/login")
-    public ResponseEntity<ApiResponse<Void>> login() {
-        memberService.login();
-        return ResponseEntity.ok()
-                .body(ApiResponse.<Void>builder()
-                        .statusCode(HttpStatus.OK)
-                        .build());
-    }
-
     @GetMapping("/me")
     @MemberAuthorize
     public ResponseEntity<ApiResponse<GetMyMemberResponse>> getMyMember(@AuthenticationPrincipal final UserDetails userDetails) {

--- a/src/main/java/com/adregamdi/member/presentation/MemberController.java
+++ b/src/main/java/com/adregamdi/member/presentation/MemberController.java
@@ -19,6 +19,7 @@ public class MemberController {
 
     @GetMapping("/login")
     public ResponseEntity<ApiResponse<Void>> login() {
+        memberService.login();
         return ResponseEntity.ok()
                 .body(ApiResponse.<Void>builder()
                         .statusCode(HttpStatus.OK)

--- a/src/main/java/com/adregamdi/member/presentation/MemberController.java
+++ b/src/main/java/com/adregamdi/member/presentation/MemberController.java
@@ -17,6 +17,14 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
     private final MemberService memberService;
 
+    @GetMapping("/login")
+    public ResponseEntity<ApiResponse<Void>> login() {
+        return ResponseEntity.ok()
+                .body(ApiResponse.<Void>builder()
+                        .statusCode(HttpStatus.OK)
+                        .build());
+    }
+
     @GetMapping("/me")
     @MemberAuthorize
     public ResponseEntity<ApiResponse<GetMyMemberResponse>> getMyMember(@AuthenticationPrincipal final UserDetails userDetails) {


### PR DESCRIPTION
## 📌 관련 이슈
- closed #29 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
변경 전
- 스프링에서 소셜 인가 코드, 액세스 토큰까지 전부 진행하고 프론트로 자체 토큰을 가지고 리다이렉트 하는 방식

변경 후
- 프론트에서 소셜 액세스 토큰 발급까지 진행 후 로그인 api를 호출해 자체 토큰을 리턴 받는 방식

특이사항
- 현재 카카오, 구글 로그인만 구현되어 있고 애플 로그인은 다음 이슈에서 해결할 예정