### PR TITLE
Refactor - 검색 API 전면 리팩토링

### DIFF
--- a/src/main/java/com/adregamdi/search/application/SearchService.java
+++ b/src/main/java/com/adregamdi/search/application/SearchService.java
@@ -1,11 +1,53 @@
 package com.adregamdi.search.application;
 
+import com.adregamdi.search.dto.SearchItemDTO;
+import com.adregamdi.search.dto.SearchType;
+import com.adregamdi.search.dto.response.SearchResponse;
+import com.adregamdi.search.infrastructure.SearchRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static com.adregamdi.core.constant.Constant.LARGE_PAGE_SIZE;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class SearchService {
+    private final SearchRepository searchRepository;
+
+    public SearchResponse search(String keyword, int page, Set<SearchType> types) {
+        List<SearchItemDTO> searchResults = searchRepository.search(keyword, page, LARGE_PAGE_SIZE, types);
+        long total = searchRepository.countTotal(keyword);
+
+        List<SearchResponse.SearchResult> travelogues = new ArrayList<>();
+        List<SearchResponse.SearchResult> shorts = new ArrayList<>();
+        List<SearchResponse.SearchResult> places = new ArrayList<>();
+
+        for (SearchItemDTO item : searchResults) {
+            SearchResponse.SearchResult result = SearchResponse.SearchResult.of(
+                    item.getId(), item.getTitle(), item.getType(), item.getDescription()
+            );
+            switch (item.getType()) {
+                case TRAVELOGUE -> travelogues.add(result);
+                case SHORTS -> shorts.add(result);
+                case PLACE -> places.add(result);
+            }
+        }
+
+        return SearchResponse.of(
+                travelogues,
+                shorts,
+                places,
+                page,
+                LARGE_PAGE_SIZE,
+                total,
+                total,
+                total
+        );
+    }
 }

--- a/src/main/java/com/adregamdi/search/application/SearchService.java
+++ b/src/main/java/com/adregamdi/search/application/SearchService.java
@@ -1,0 +1,11 @@
+package com.adregamdi.search.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class SearchService {
+}

--- a/src/main/java/com/adregamdi/search/dto/SearchItemDTO.java
+++ b/src/main/java/com/adregamdi/search/dto/SearchItemDTO.java
@@ -1,0 +1,17 @@
+package com.adregamdi.search.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchItemDTO {
+    private Long id;
+    private String title;
+    private SearchType type;
+    private String description;
+}

--- a/src/main/java/com/adregamdi/search/dto/SearchType.java
+++ b/src/main/java/com/adregamdi/search/dto/SearchType.java
@@ -1,0 +1,5 @@
+package com.adregamdi.search.dto;
+
+public enum SearchType {
+    TRAVELOGUE, SHORTS, PLACE
+}

--- a/src/main/java/com/adregamdi/search/dto/response/SearchResponse.java
+++ b/src/main/java/com/adregamdi/search/dto/response/SearchResponse.java
@@ -1,0 +1,70 @@
+package com.adregamdi.search.dto.response;
+
+import com.adregamdi.search.dto.SearchType;
+import lombok.Builder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Builder
+public record SearchResponse(
+        List<SearchResult> travelogues,
+        List<SearchResult> shorts,
+        List<SearchResult> places,
+        int currentPage,
+        int pageSize,
+        long totalTravelogues,
+        long totalShorts,
+        long totalPlaces
+) {
+    public static SearchResponse of(
+            List<SearchResult> travelogues,
+            List<SearchResult> shorts,
+            List<SearchResult> places,
+            int currentPage,
+            int pageSize,
+            long totalTravelogues,
+            long totalShorts,
+            long totalPlaces
+    ) {
+        return SearchResponse.builder()
+                .travelogues(travelogues)
+                .shorts(shorts)
+                .places(places)
+                .currentPage(currentPage)
+                .pageSize(pageSize)
+                .totalTravelogues(totalTravelogues)
+                .totalShorts(totalShorts)
+                .totalPlaces(totalPlaces)
+                .build();
+    }
+
+    public long getTotalItems() {
+        return totalTravelogues + totalShorts + totalPlaces;
+    }
+
+    public List<SearchResult> getAllResults() {
+        List<SearchResult> allResults = new ArrayList<>();
+        allResults.addAll(travelogues);
+        allResults.addAll(shorts);
+        allResults.addAll(places);
+        return allResults;
+    }
+
+    @Builder
+    public record SearchResult(
+            Long id,
+            String title,
+            SearchType type,
+            String description
+    ) {
+        public static SearchResult of(Long id, String title, SearchType type, String description) {
+            return SearchResult.builder()
+                    .id(id)
+                    .title(title)
+                    .type(type)
+                    .description(description)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/adregamdi/search/infrastructure/SearchRepository.java
+++ b/src/main/java/com/adregamdi/search/infrastructure/SearchRepository.java
@@ -1,0 +1,13 @@
+package com.adregamdi.search.infrastructure;
+
+import com.adregamdi.search.dto.SearchItemDTO;
+import com.adregamdi.search.dto.SearchType;
+
+import java.util.List;
+import java.util.Set;
+
+public interface SearchRepository {
+    List<SearchItemDTO> search(final String keyword, final int page, final int pageSize, final Set<SearchType> types);
+
+    long countTotal(final String keyword);
+}

--- a/src/main/java/com/adregamdi/search/infrastructure/SearchRepositoryImpl.java
+++ b/src/main/java/com/adregamdi/search/infrastructure/SearchRepositoryImpl.java
@@ -1,0 +1,115 @@
+package com.adregamdi.search.infrastructure;
+
+import com.adregamdi.search.dto.SearchItemDTO;
+import com.adregamdi.search.dto.SearchType;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.adregamdi.place.domain.QPlace.place;
+import static com.adregamdi.shorts.domain.QShorts.shorts;
+import static com.adregamdi.travelogue.domain.QTravelogue.travelogue;
+
+@Repository
+@RequiredArgsConstructor
+public class SearchRepositoryImpl implements SearchRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<SearchItemDTO> search(final String keyword, final int page, final int pageSize, final Set<SearchType> types) {
+        List<SearchItemDTO> results = new ArrayList<>();
+
+        if (types.contains(SearchType.TRAVELOGUE)) {
+            results.addAll(searchTravelogues(keyword, page, pageSize));
+        }
+        if (types.contains(SearchType.SHORTS)) {
+            results.addAll(searchShorts(keyword, page, pageSize));
+        }
+        if (types.contains(SearchType.PLACE)) {
+            results.addAll(searchPlaces(keyword, page, pageSize));
+        }
+
+        return results.stream()
+                .skip((long) page * pageSize)
+                .limit(pageSize)
+                .toList();
+    }
+
+    private List<SearchItemDTO> searchTravelogues(String keyword, int page, int pageSize) {
+        return queryFactory
+                .select(Projections.constructor(SearchItemDTO.class,
+                        travelogue.travelogueId,
+                        travelogue.title,
+                        Expressions.constant(SearchType.TRAVELOGUE),
+                        travelogue.introduction))
+                .from(travelogue)
+                .where(keywordCondition(keyword, travelogue.title))
+                .offset((long) page * pageSize)
+                .limit(pageSize)
+                .fetch();
+    }
+
+    private List<SearchItemDTO> searchShorts(String keyword, int page, int pageSize) {
+        return queryFactory
+                .select(Projections.constructor(SearchItemDTO.class,
+                        shorts.id,
+                        shorts.title,
+                        Expressions.constant(SearchType.SHORTS),
+                        shorts.thumbnailUrl))
+                .from(shorts)
+                .where(keywordCondition(keyword, shorts.title))
+                .offset((long) page * pageSize)
+                .limit(pageSize)
+                .fetch();
+    }
+
+    private List<SearchItemDTO> searchPlaces(String keyword, int page, int pageSize) {
+        return queryFactory
+                .select(Projections.constructor(SearchItemDTO.class,
+                        place.placeId,
+                        place.title,
+                        Expressions.constant(SearchType.PLACE),
+                        place.introduction))
+                .from(place)
+                .where(keywordCondition(keyword, place.title))
+                .offset((long) page * pageSize)
+                .limit(pageSize)
+                .fetch();
+    }
+
+    @Override
+    public long countTotal(final String keyword) {
+        Long travelogueCount = Optional.ofNullable(queryFactory
+                .select(travelogue.count())
+                .from(travelogue)
+                .where(keywordCondition(keyword, travelogue.title))
+                .fetchOne()).orElse(0L);
+
+        Long shortsCount = Optional.ofNullable(queryFactory
+                .select(shorts.count())
+                .from(shorts)
+                .where(keywordCondition(keyword, shorts.title))
+                .fetchOne()).orElse(0L);
+
+        Long placeCount = Optional.ofNullable(queryFactory
+                .select(place.count())
+                .from(place)
+                .where(keywordCondition(keyword, place.title))
+                .fetchOne()).orElse(0L);
+
+        return travelogueCount + shortsCount + placeCount;
+    }
+
+    private BooleanExpression keywordCondition(String keyword, StringPath field) {
+        return keyword != null && !keyword.isEmpty() ? field.containsIgnoreCase(keyword) : null;
+    }
+}

--- a/src/main/java/com/adregamdi/search/presentation/SearchController.java
+++ b/src/main/java/com/adregamdi/search/presentation/SearchController.java
@@ -1,0 +1,11 @@
+package com.adregamdi.search.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/search")
+@RestController
+public class SearchController {
+}

--- a/src/main/java/com/adregamdi/search/presentation/SearchController.java
+++ b/src/main/java/com/adregamdi/search/presentation/SearchController.java
@@ -1,11 +1,38 @@
 package com.adregamdi.search.presentation;
 
+import com.adregamdi.core.handler.ApiResponse;
+import com.adregamdi.search.application.SearchService;
+import com.adregamdi.search.dto.SearchType;
+import com.adregamdi.search.dto.response.SearchResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.EnumSet;
+import java.util.Set;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/search")
 @RestController
 public class SearchController {
+    private final SearchService searchService;
+
+    @GetMapping
+//    @MemberAuthorize
+    public ResponseEntity<ApiResponse<SearchResponse>> search(
+            @RequestParam(required = false) final String keyword,
+            @RequestParam(defaultValue = "0") final int page,
+            @RequestParam(required = false) final Set<SearchType> types
+    ) {
+        return ResponseEntity.ok()
+                .body(ApiResponse.<SearchResponse>builder()
+                        .statusCode(HttpStatus.OK.value())
+                        .data(searchService.search(keyword, page, types != null ? types : EnumSet.allOf(SearchType.class)))
+                        .build()
+                );
+    }
 }

--- a/src/main/java/com/adregamdi/search/presentation/SearchController.java
+++ b/src/main/java/com/adregamdi/search/presentation/SearchController.java
@@ -1,5 +1,6 @@
 package com.adregamdi.search.presentation;
 
+import com.adregamdi.core.annotation.MemberAuthorize;
 import com.adregamdi.core.handler.ApiResponse;
 import com.adregamdi.search.application.SearchService;
 import com.adregamdi.search.dto.SearchType;
@@ -22,7 +23,7 @@ public class SearchController {
     private final SearchService searchService;
 
     @GetMapping
-//    @MemberAuthorize
+    @MemberAuthorize
     public ResponseEntity<ApiResponse<SearchResponse>> search(
             @RequestParam(required = false) final String keyword,
             @RequestParam(defaultValue = "0") final int page,


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #39 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
1. 여행기, 쇼츠, 장소 검색 가능한 API 새로 구현
- 키워드가 없는 경우에도 검색이 가능 (전체 목록 조회).
- types 파라미터를 통해 특정 타입(TRAVELOGUE, SHORTS, PLACE)만 검색하거나 모든 타입을 검색.
- 타입이 지정되지 않으면 기본적으로 모든 타입을 검색.
- 각 엔티티(여행기, 쇼츠, 장소)의 title 필드에 대해 키워드를 대소문자 구분 없이 포함하는지 확인.
- 최종 응답에는 각 타입별 결과 리스트와 총 개수 정보가 포함.

2. 문제 및 개선점
- 각 타입별로 별도의 쿼리를 실행하므로, 대용량 데이터 조회 시 성능 저하 예상됨.
- 페이지네이션이 각 타입별로 적용되고 있어, 전체 결과에 대한 정확한 페이지네이션이 어려울 것 같음.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
- 여행기, 쇼츠, 장소 데이터 없는 상태에서 타입 지정 없이 통합 검색.
![image](https://github.com/user-attachments/assets/65f014dd-30b1-4df0-8ae0-4c9dccfe04f5)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
- query dsl은 fullJoin, union 함수가 안 먹는다.
