### PR TITLE
[#50] 이미지 API 구현

### DIFF
--- a/src/main/java/com/adregamdi/core/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/adregamdi/core/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.adregamdi.core.handler;
 
+import com.adregamdi.media.exception.ImageException;
 import com.adregamdi.member.exception.MemberException;
 import com.adregamdi.notification.exception.NotificationException;
 import com.adregamdi.place.exception.PlaceException;
@@ -74,7 +75,8 @@ public class GlobalExceptionHandler {
             TravelogueException.TravelogueNotFoundException.class,
             TravelogueException.TravelogueImageNotFoundException.class,
             TravelogueException.TravelogueDayNotFoundException.class,
-            ShortsException.ShortsNotFoundException.class
+            ShortsException.ShortsNotFoundException.class,
+            ImageException.ImageNotFoundException.class
     })
     public ResponseEntity<ErrorResponse> handleNotFoundException(final RuntimeException exception) {
         log.warn(exception.getMessage());
@@ -101,7 +103,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(value = {
             TravelException.InvalidTravelDateException.class,
             TravelException.InvalidTravelDayException.class,
-            ShortsException.ShortsNOTWRITERException.class
+            ShortsException.ShortsNOTWRITERException.class,
+            ImageException.UnSupportedImageTypeException.class,
+            ImageException.InvalidFileNameException.class,
+            ImageException.InvalidImageLengthException.class
     })
     public ResponseEntity<ErrorResponse> handleCustomBadRequestException(final RuntimeException exception) {
         log.warn(exception.getMessage());

--- a/src/main/java/com/adregamdi/media/application/ImageService.java
+++ b/src/main/java/com/adregamdi/media/application/ImageService.java
@@ -1,40 +1,35 @@
 package com.adregamdi.media.application;
 
-import lombok.RequiredArgsConstructor;
-import org.imgscalr.Scalr;
-import org.springframework.stereotype.Service;
+import com.adregamdi.media.domain.ImageTarget;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Objects;
+import java.util.List;
 
-@Service
-@RequiredArgsConstructor
-public class ImageService {
+public interface ImageService {
 
-    private final FileUploadService fileUploadService;
+    String uploadImage(MultipartFile image, String memberId, ImageTarget imageTarget) throws IOException;
 
-    private final static int IMAGE_RESIZE_TARGET_WIDTH = 650;
+    List<String> uploadImages(List<MultipartFile> imageList, String memberId, ImageTarget imageTarget) throws IOException;
 
-    public String getEncodedFileName(String key) {
-        return URLEncoder.encode(key, StandardCharsets.UTF_8).replaceAll("\\+", "%20");
-    }
+    void saveImage(String imageUrl, ImageTarget imageTarget);
 
-    public byte[] resizeImage(MultipartFile multipartFile) throws IOException {
-        BufferedImage originalImage = ImageIO.read(multipartFile.getInputStream());
-        BufferedImage resizedImage =
-                Scalr.resize(originalImage, Scalr.Method.QUALITY, Scalr.Mode.FIT_TO_WIDTH, IMAGE_RESIZE_TARGET_WIDTH, Scalr.THRESHOLD_QUALITY_BALANCED);
-        String fileExtension = fileUploadService.extractFileExtension(Objects.requireNonNull(multipartFile));
+    void saveImages(List<String> imageUrlList, ImageTarget imageTarget);
 
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        ImageIO.write(resizedImage, fileExtension, outputStream);
+    void saveTargetNo(List<String> imageUrlList, ImageTarget imageTarget, Long targetNo);
 
-        return outputStream.toByteArray();
-    }
+    void saveTargetNo(String imageUrl, ImageTarget imageTarget, Long targetNo);
+
+    void updateImage(String newImageUrl, ImageTarget imageTarget, Long targetNo);
+
+    void deleteImageList(List<String> imageUrlList);
+
+    void deleteImageFromStorage(String imageUrl);
+
+    void deleteImageFromDB(String imageUrl);
+
+    void deleteUnassignedImages();
+
+    byte[] resizeImage(MultipartFile multipartFile) throws IOException;
 
 }

--- a/src/main/java/com/adregamdi/media/application/ImageServiceImpl.java
+++ b/src/main/java/com/adregamdi/media/application/ImageServiceImpl.java
@@ -1,0 +1,233 @@
+package com.adregamdi.media.application;
+
+import com.adregamdi.media.domain.Image;
+import com.adregamdi.media.domain.ImageTarget;
+import com.adregamdi.media.exception.ImageException;
+import com.adregamdi.media.infrastructure.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.imgscalr.Scalr;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ImageServiceImpl implements ImageService {
+
+    private final FileUploadService fileUploadService;
+    private final ImageValidService imageValidService;
+    private final ImageRepository imageRepository;
+
+    private final static int IMAGE_RESIZE_TARGET_WIDTH = 650;
+
+    private Image getImageByImageUrl(String imageUrl) {
+        Image image = imageRepository.findImageByImageUrl(imageUrl)
+                .orElseThrow(() -> new ImageException.ImageNotFoundException(imageUrl));
+        log.info("성공적으로 이미지를 조회하였습니다. imageUrl: {}", imageUrl);
+        return image;
+    }
+
+    private Image getImageByImageTargetAndTargetNo(ImageTarget imageTarget, Long targetNo) {
+        Image image = imageRepository.findImageByImageTargetAndTargetNo(imageTarget, targetNo)
+                .orElseThrow(() -> new ImageException.ImageNotFoundException(targetNo));
+        log.info("성공적으로 이미지를 조회하였습니다. targetNo: {}", targetNo);
+        return image;
+    }
+
+    @Override
+    public String uploadImage(MultipartFile image, String memberId, ImageTarget imageTarget) throws IOException {
+
+        imageValidService.checkImageFile(image.getOriginalFilename());
+
+        String dirName = imageTarget.toString() + "/" + memberId;
+        String key = fileUploadService.buildKey(image, dirName);
+        byte[] resizedImage = resizeImage(image);
+
+        return fileUploadService.uploadFile(resizedImage, key);
+    }
+
+    @Override
+    public List<String> uploadImages(List<MultipartFile> imageList, String memberId, ImageTarget imageTarget) throws IOException {
+
+        imageValidService.checkMaxLength(imageList, imageTarget);
+
+        List<String> uploadedUrls = new ArrayList<>();
+        for (MultipartFile image : imageList) {
+            String url = uploadImage(image, memberId, imageTarget);
+            uploadedUrls.add(url);
+        }
+
+        return uploadedUrls;
+    }
+
+    @Override
+    @Transactional
+    public void saveImage(String imageUrl, ImageTarget imageTarget) {
+
+        Image image = Image.builder()
+                .imageUrl(imageUrl)
+                .imageTarget(imageTarget)
+                .build();
+
+        imageRepository.save(image);
+    }
+
+    @Override
+    @Transactional
+    public void saveImages(List<String> imageUrlList, ImageTarget imageTarget) {
+        List<Image> imageList = new ArrayList<>();
+
+        for (String imageUrl : imageUrlList) {
+            imageList.add(
+                    Image.builder()
+                            .imageUrl(imageUrl)
+                            .imageTarget(imageTarget)
+                            .build()
+            );
+        }
+
+        imageRepository.saveAll(imageList);
+        log.info("이미지 리스트가 DB에 추가되었습니다.");
+    }
+
+    @Override
+    public void saveTargetNo(List<String> imageUrlList, ImageTarget imageTarget, Long targetNo) {
+
+        for (String imageUrl : imageUrlList) {
+            saveTargetNo(imageUrl, imageTarget, targetNo);
+        }
+    }
+
+    @Override
+    public void saveTargetNo(String imageUrl, ImageTarget imageTarget, Long targetNo) {
+
+        log.info("이미지에 아이디를 할당합니다. imageTarget: {}, targetNo: {}", imageTarget, targetNo);
+        String filename = imageValidService.getFileNameFromUrl(imageUrl);
+        imageValidService.checkImageFile(filename);
+
+        Image image = getImageByImageUrl(imageUrl);
+        image.updateImageTarget(imageTarget);
+        image.updateTargetNo(targetNo);
+        log.info("{} 번의 이미지가 {} 의 {} 번의 엔테티로 할당되었습니다,", image.getImageNo(), image.getImageTarget(), image.getTargetNo());
+    }
+
+    @Override
+    @Transactional
+    public void updateImage(String newImageUrl, ImageTarget imageTarget, Long targetNo) {
+
+        // 이미지 유효성 검증
+        String filename = imageValidService.getFileNameFromUrl(newImageUrl);
+        imageValidService.checkImageFile(filename);
+
+        Image image = getImageByImageTargetAndTargetNo(imageTarget, targetNo);
+        String currentImageUrl = image.getImageUrl();
+
+        if (imageValidService.isSameImage(currentImageUrl, newImageUrl)) {
+            return;
+        }
+
+        deleteImageFromStorage(currentImageUrl);
+        image.updateImageUrl(newImageUrl);
+        log.info("{} - {}의 이미지가 변경되었습니다.", image.getImageTarget(), targetNo);
+    }
+
+    @Override
+    @Transactional
+    public void deleteImageList(List<String> imageUrlList) {
+
+        List<Image> existingImages = imageRepository.findByImageUrlIn(imageUrlList);
+
+        List<String> existingUrls = existingImages.stream()
+                .map(Image::getImageUrl)
+                .toList();
+
+        // S3에서 이미지 삭제
+        for (String imageUrl : existingUrls) {
+            fileUploadService.deleteFile(imageUrl);
+        }
+
+        // DB에서 이미지 정보 일괄 삭제
+        int deletedCount = imageRepository.deleteAllByImageUrlIn(existingUrls);
+
+        log.info("DB와 Storage 에서 {}개의 이미지가 삭제되었습니다.", deletedCount);
+    }
+
+    @Override
+    public void deleteImageFromStorage(String imageUrl) {
+
+        fileUploadService.deleteFile(imageUrl);
+        log.info("{} 이미지가 Storage 에서 이미지가 삭제되었습니다.", imageUrl);
+    }
+
+    @Override
+    @Transactional
+    public void deleteImageFromDB(String imageUrl) {
+        Image image = getImageByImageUrl(imageUrl);
+        imageRepository.delete(image);
+        log.info("{} 이미지가 DB에서 삭제되었습니다.", imageUrl);
+    }
+
+    @Override
+    public byte[] resizeImage(MultipartFile multipartFile) throws IOException {
+
+        log.info("{} 이미지를 리사이징합니다.", multipartFile.getOriginalFilename());
+        String fileExtension = imageValidService.getFileExtension(Objects.requireNonNull(multipartFile.getOriginalFilename()));
+        log.info("fileExtension: {}", fileExtension);
+
+        // HEIC/HEIF 파일은 리사이징하지 않고 그대로 반환
+        if (imageValidService.isHeifOrHeic(fileExtension)) {
+            return multipartFile.getBytes();
+        }
+
+        BufferedImage originalImage = ImageIO.read(multipartFile.getInputStream());
+        if (originalImage == null) {
+            throw new IOException("이미지 리사이징 중 오류가 발생하였습니다.");
+        }
+
+        BufferedImage resizedImage = Scalr.resize(
+                originalImage,
+                Scalr.Method.QUALITY,
+                Scalr.Mode.FIT_TO_WIDTH,
+                IMAGE_RESIZE_TARGET_WIDTH,
+                Scalr.THRESHOLD_QUALITY_BALANCED
+        );
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        boolean success = ImageIO.write(resizedImage, fileExtension, outputStream);
+
+        if (!success) {
+            throw new IOException("이미지를 " + fileExtension + " 형식으로 저장할 수 없습니다.");
+        }
+
+        log.info("성공적으로 이미지가 리사이징되었습니다.");
+        return outputStream.toByteArray();
+    }
+
+    @Override
+    @Scheduled(cron = "0 0 1 * * ?") // 매일 새벽 1시에 실행
+    public void deleteUnassignedImages() {
+        LocalDateTime cutoffDate = LocalDateTime.now().minusDays(7); // 일주일 동안 할당되지 않은 이미지 삭제
+        log.info("{}일 이후의 할당되지 않은 사진들을 삭제합니다.", cutoffDate);
+        List<String> unassignedImageUrlList = imageRepository.findUnassignedImagesBeforeDate(cutoffDate);
+
+        // S3에서 이미지 삭제
+        for (String url : unassignedImageUrlList) {
+            fileUploadService.deleteFile(url);
+        }
+
+        int deletedCount = imageRepository.deleteAllByImageUrlIn(unassignedImageUrlList);
+        log.info("DB와 Storage 에서 {}개의 이미지가 삭제되었습니다.", deletedCount);
+    }
+}

--- a/src/main/java/com/adregamdi/media/application/ImageValidService.java
+++ b/src/main/java/com/adregamdi/media/application/ImageValidService.java
@@ -1,0 +1,89 @@
+package com.adregamdi.media.application;
+
+import com.adregamdi.media.domain.ImageTarget;
+import com.adregamdi.media.exception.ImageException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+@Component
+public class ImageValidService {
+
+    private final static int TRAVELOGUE_IMAGE_MAX_LENGTH = 20;
+    private final static int PLACE_REVIEW_IMAGE_MAX_LENGTH = 3;
+
+    public String checkImageFile(String fileName) {
+        if (isFileNameInvalid(fileName)) {
+            throw new ImageException.InvalidFileNameException(fileName);
+        }
+
+        String extension = getFileExtension(fileName);
+
+        if (isImageExtension(extension)) {
+            return extension;
+        } else {
+            throw new ImageException.UnSupportedImageTypeException(fileName);
+        }
+    }
+
+    public void checkMaxLength(List<MultipartFile> imageFiles, ImageTarget imageTarget) {
+
+        int requestListLength = imageFiles.size();
+        int maxLength = getMaxLengthByImageTarget(imageTarget);
+
+        if (maxLength < requestListLength) {
+            throw new ImageException.InvalidImageLengthException("이미지 업로드 개수는 " + maxLength + "개 이하입니다.");
+        }
+
+    }
+
+    private int getMaxLengthByImageTarget(ImageTarget imageTarget) {
+        return switch (imageTarget) {
+            case TRAVELOGUE -> TRAVELOGUE_IMAGE_MAX_LENGTH;
+            case PLACEREVIEW -> PLACE_REVIEW_IMAGE_MAX_LENGTH;
+            default -> 1;
+        };
+    }
+
+    public String getFileExtension(String fileName) {
+        int dotIndex = fileName.lastIndexOf(".");
+        return fileName.substring(dotIndex + 1);
+    }
+
+    private boolean isFileNameInvalid(String fileName) {
+        return fileName == null || fileName.isBlank() || !fileName.contains(".");
+    }
+
+    private boolean isImageExtension(String extension) {
+
+        String[] imageExtensions = {"jpg", "jpeg", "png", "gif", "bmp", "heic", "heif"};
+
+        for (String ext : imageExtensions) {
+            if (extension.equalsIgnoreCase(ext)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public String getFileNameFromUrl(String url) {
+        if (url == null || url.lastIndexOf('.') == -1) {
+            return null; // 확장자를 찾을 수 없으면 null 반환
+        }
+
+        return url.substring(url.lastIndexOf('/') + 1);
+    }
+
+    public boolean isSameImage(String image1, String image2) {
+        return Objects.equals(image1, image2);
+    }
+
+    public boolean isHeifOrHeic(String fileExtension) {
+        return "heif".equalsIgnoreCase(fileExtension) || "heic".equalsIgnoreCase(fileExtension);
+    }
+}

--- a/src/main/java/com/adregamdi/media/domain/Image.java
+++ b/src/main/java/com/adregamdi/media/domain/Image.java
@@ -1,0 +1,60 @@
+package com.adregamdi.media.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "tbl_image")
+public class Image {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_no")
+    private Long imageNo;
+
+    @Column(name = "image_url", nullable = false)
+    @Comment(value = "이미지 URL")
+    private String imageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "image_target")
+    @Comment(value = "관련 엔티티")
+    private ImageTarget imageTarget;
+
+    @Column(name = "target_id")
+    @Comment(value = "관련 엔티티 식별 값")
+    private Long targetNo;
+
+    @Column(name = "create_date", updatable = false)
+    @Comment(value = "이미지 생성일")
+    private LocalDateTime createDate;
+
+
+    @Builder
+    public Image(Long imageNo, String imageUrl, ImageTarget imageTarget, Long targetNo) {
+        this.imageNo = imageNo;
+        this.imageUrl = imageUrl;
+        this.imageTarget = imageTarget;
+        this.targetNo = targetNo;
+        this.createDate = LocalDateTime.now();
+    }
+
+    public void updateTargetNo(Long targetNo) {
+        this.targetNo = targetNo;
+    }
+
+    public void updateImageTarget(ImageTarget imageTarget) {
+        this.imageTarget = imageTarget;
+    }
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/adregamdi/media/domain/ImageTarget.java
+++ b/src/main/java/com/adregamdi/media/domain/ImageTarget.java
@@ -1,0 +1,7 @@
+package com.adregamdi.media.domain;
+
+public enum ImageTarget {
+    PROFILE,
+    PLACEREVIEW,
+    TRAVELOGUE
+}

--- a/src/main/java/com/adregamdi/media/dto/request/DeleteImagesRequest.java
+++ b/src/main/java/com/adregamdi/media/dto/request/DeleteImagesRequest.java
@@ -1,0 +1,9 @@
+package com.adregamdi.media.dto.request;
+
+import java.util.List;
+
+public record DeleteImagesRequest(
+        List<String> images
+) {
+
+}

--- a/src/main/java/com/adregamdi/media/dto/response/CreateImageListResponse.java
+++ b/src/main/java/com/adregamdi/media/dto/response/CreateImageListResponse.java
@@ -1,0 +1,17 @@
+package com.adregamdi.media.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateImageListResponse {
+
+    private List<String> imageList;
+}

--- a/src/main/java/com/adregamdi/media/dto/response/CreateImageResponse.java
+++ b/src/main/java/com/adregamdi/media/dto/response/CreateImageResponse.java
@@ -1,0 +1,15 @@
+package com.adregamdi.media.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateImageResponse {
+
+    private String imageUrl;
+}

--- a/src/main/java/com/adregamdi/media/exception/ImageException.java
+++ b/src/main/java/com/adregamdi/media/exception/ImageException.java
@@ -1,0 +1,51 @@
+package com.adregamdi.media.exception;
+
+import com.adregamdi.shorts.exception.ShortsException;
+
+public class ImageException extends RuntimeException{
+    public ImageException(String message) {
+        super(message);
+    }
+    public ImageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public static class ImageNotFoundException extends ShortsException {
+
+        private final static String NOT_FOUND_MESSAGE = "이미지가 존재하지 않습니다.";
+
+        public ImageNotFoundException() {super(NOT_FOUND_MESSAGE);}
+
+        public ImageNotFoundException(final Object object) {
+            super(String.format(NOT_FOUND_MESSAGE + "- request info => %s", object));
+        }
+    }
+    
+    public static class InvalidFileNameException extends ImageException {
+
+        public InvalidFileNameException() {super("파일 이름이 유효하지 않습니다.");}
+
+        public InvalidFileNameException(final Object object) {
+            super(String.format("파일 이름이 유효하지 않습니다. - request info => %s", object));
+        }
+    }
+
+    public static class UnSupportedImageTypeException extends ImageException {
+
+        public UnSupportedImageTypeException() { super("지원하는 이미지 파일이 아닙니다."); }
+
+        public UnSupportedImageTypeException(final Object object) {
+            super(String.format("지원하는 이미지 파일이 아닙니다. - request info => %s", object));
+        }
+    }
+
+    public static class InvalidImageLengthException extends ImageException {
+
+        public InvalidImageLengthException(final String message) { super(message); }
+
+        public InvalidImageLengthException(final String message, final Object object) {
+            super(String.format(message + "- request info => %s", object));
+        }
+    }
+}
+

--- a/src/main/java/com/adregamdi/media/infrastructure/ImageRepository.java
+++ b/src/main/java/com/adregamdi/media/infrastructure/ImageRepository.java
@@ -1,0 +1,28 @@
+package com.adregamdi.media.infrastructure;
+
+import com.adregamdi.media.domain.Image;
+import com.adregamdi.media.domain.ImageTarget;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    Optional<Image> findImageByImageUrl(String imageUrl);
+
+    Optional<Image> findImageByImageTargetAndTargetNo(ImageTarget imageTarget, Long targetNo);
+
+    List<Image> findByImageUrlIn(List<String> imageUrls);
+
+    @Query("SELECT i.imageUrl FROM Image i WHERE i.targetNo IS NULL AND i.createDate < :date")
+    List<String> findUnassignedImagesBeforeDate(@Param("date") LocalDateTime date);
+
+    @Query("DELETE FROM Image i WHERE i.imageUrl IN :imageUrls")
+    @Modifying
+    int deleteAllByImageUrlIn(@Param("imageUrls") List<String> imageUrls);
+}

--- a/src/main/java/com/adregamdi/media/presentation/ImageController.java
+++ b/src/main/java/com/adregamdi/media/presentation/ImageController.java
@@ -1,0 +1,83 @@
+package com.adregamdi.media.presentation;
+
+import com.adregamdi.core.annotation.MemberAuthorize;
+import com.adregamdi.core.handler.ApiResponse;
+import com.adregamdi.media.application.ImageService;
+import com.adregamdi.media.domain.ImageTarget;
+import com.adregamdi.media.dto.response.CreateImageListResponse;
+import com.adregamdi.media.dto.response.CreateImageResponse;
+import jakarta.validation.constraints.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/images")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping
+    @MemberAuthorize
+    public ResponseEntity<ApiResponse<CreateImageResponse>> createImage(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam("image") MultipartFile image,
+            @RequestParam("image_target") @Pattern(regexp = "(?i)^(PROFILE|PLACEREVIEW|TRAVELOGUE)$",
+                    message = "유효한 ImageTarget이 아닙니다 (PROFILE, PLACEREVIEW, TRAVELOGUE)") String imageTargetStr
+            ) throws IOException {
+
+
+        String memberId = userDetails.getUsername();
+        ImageTarget imageTarget = ImageTarget.valueOf(imageTargetStr.toUpperCase());
+        String imageUrl = imageService.uploadImage(image, memberId, imageTarget);
+        imageService.saveImage(imageUrl, imageTarget);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.<CreateImageResponse>builder()
+                        .statusCode(HttpStatus.OK.value())
+                        .data(new CreateImageResponse(imageUrl))
+                        .build());
+    }
+
+    @PostMapping("/list")
+    @MemberAuthorize
+    public ResponseEntity<ApiResponse<CreateImageListResponse>> createImages(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam("images") List<MultipartFile> imgList,
+            @RequestParam("image_target") @Pattern(regexp = "(?i)^(PROFILE|PLACEREVIEW|TRAVELOGUE)$",
+                    message = "유효한 ImageTarget이 아닙니다 (PROFILE, PLACEREVIEW, TRAVELOGUE)") String imageTargetStr
+    ) throws IOException {
+        String memberId = userDetails.getUsername();
+        ImageTarget imageTarget = ImageTarget.valueOf(imageTargetStr.toUpperCase());
+        List<String> imageUrlList = imageService.uploadImages(imgList, memberId, imageTarget);
+        imageService.saveImages(imageUrlList, imageTarget);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.<CreateImageListResponse>builder()
+                        .statusCode(HttpStatus.OK.value())
+                        .data(new CreateImageListResponse(imageUrlList) )
+                        .build());
+    }
+
+    @DeleteMapping
+    @MemberAuthorize
+    public ResponseEntity<ApiResponse<Void>> deleteImages(
+            @RequestPart("images") List<String> imageUrlList
+    ) {
+
+        imageService.deleteImageList(imageUrlList);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.<Void>builder()
+                        .statusCode(HttpStatus.OK.value())
+                        .build());
+    }
+}

--- a/src/main/java/com/adregamdi/media/presentation/ImageController.java
+++ b/src/main/java/com/adregamdi/media/presentation/ImageController.java
@@ -4,6 +4,7 @@ import com.adregamdi.core.annotation.MemberAuthorize;
 import com.adregamdi.core.handler.ApiResponse;
 import com.adregamdi.media.application.ImageService;
 import com.adregamdi.media.domain.ImageTarget;
+import com.adregamdi.media.dto.request.DeleteImagesRequest;
 import com.adregamdi.media.dto.response.CreateImageListResponse;
 import com.adregamdi.media.dto.response.CreateImageResponse;
 import jakarta.validation.constraints.Pattern;
@@ -70,10 +71,10 @@ public class ImageController {
     @DeleteMapping
     @MemberAuthorize
     public ResponseEntity<ApiResponse<Void>> deleteImages(
-            @RequestPart("images") List<String> imageUrlList
+            @RequestBody() DeleteImagesRequest request
     ) {
 
-        imageService.deleteImageList(imageUrlList);
+        imageService.deleteImageList(request.images());
 
         return ResponseEntity.ok()
                 .body(ApiResponse.<Void>builder()


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #50 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- 현재 이미지는 각각의 도메인에서 별도의 엔티티로 관리합니다.
- 이미지 API는 `쓰기`만 발생시키는 API입니다.
- 이미지 리스트 업로드 혹은 단일 업로드 요청을 하면 storage 업로드 후 url만을 반환합니다.
- 반환 받은 url로 각각의 엔티티로 저장하면 됩니다.
- 여기서 주의할 점은, 각각의 엔티티를 저장할 시에 `imageService.saveTargetNo` 메서드를 이용해주어야 합니다. 

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린
샷을 첨부해주세요 -->
이미지 관리 플로우는 다음과 같습니다.
![image-manage](https://github.com/user-attachments/assets/1ad0c8d9-686b-4e3d-be52-984e93598aa9)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
