### PR TITLE
Feature - 내 리뷰 조회 API 구현 외

### DIFF
--- a/src/main/java/com/adregamdi/member/application/MemberService.java
+++ b/src/main/java/com/adregamdi/member/application/MemberService.java
@@ -20,6 +20,7 @@ import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @Slf4j
@@ -45,14 +46,15 @@ public class MemberService {
      */
     @Transactional
     public void update(final UpdateMyMemberRequest request, final String username) {
+        Member another = memberRepository.findByHandle(request.handle());
         Member member = memberRepository.findById(UUID.fromString(username))
                 .orElseThrow(() -> new MemberNotFoundException(username));
 
-        if (member.getHandle().equals(request.handle())) {
+        if (another != null && !Objects.equals(another.getHandle(), member.getHandle())) {
             throw new HandleExistException(request.handle());
         }
 
-        member.updateMember(request);
+        member.updateMember(request.profile(), request.handle());
     }
 
     /*

--- a/src/main/java/com/adregamdi/member/domain/Member.java
+++ b/src/main/java/com/adregamdi/member/domain/Member.java
@@ -2,7 +2,6 @@ package com.adregamdi.member.domain;
 
 import com.adregamdi.core.entity.BaseTime;
 import com.adregamdi.core.oauth2.dto.SignUpDTO;
-import com.adregamdi.member.dto.request.UpdateMyMemberRequest;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -63,10 +62,9 @@ public class Member extends BaseTime {
         this.memberStatus = true;
     }
 
-    public void updateMember(UpdateMyMemberRequest request) {
-        this.name = request.name();
-        this.profile = request.profile();
-        this.handle = request.handle();
+    public void updateMember(String profile, String handle) {
+        this.profile = profile;
+        this.handle = handle;
     }
 
     public void updateSocialAccessToken(String socialAccessToken) {

--- a/src/main/java/com/adregamdi/member/dto/request/UpdateMyMemberRequest.java
+++ b/src/main/java/com/adregamdi/member/dto/request/UpdateMyMemberRequest.java
@@ -6,9 +6,6 @@ import jakarta.validation.constraints.NotNull;
 public record UpdateMyMemberRequest(
         @NotNull
         @NotEmpty
-        String name,
-        @NotNull
-        @NotEmpty
         String profile,
         @NotNull
         @NotEmpty

--- a/src/main/java/com/adregamdi/member/infrastructure/MemberRepository.java
+++ b/src/main/java/com/adregamdi/member/infrastructure/MemberRepository.java
@@ -34,4 +34,6 @@ public interface MemberRepository extends JpaRepository<Member, UUID> {
             AND m.updatedAt < :date
             """)
     void deleteByMemberStatusAndUpdatedAt(@Param("date") final LocalDateTime date);
+
+    Member findByHandle(String handle);
 }

--- a/src/main/java/com/adregamdi/place/application/PlaceService.java
+++ b/src/main/java/com/adregamdi/place/application/PlaceService.java
@@ -58,5 +58,5 @@ public interface PlaceService {
     /*
      * [내 리뷰 조회]
      * */
-    GetMyPlaceReviewResponse getReview(final String username);
+    GetMyPlaceReviewResponse getReview(final String memberId);
 }

--- a/src/main/java/com/adregamdi/place/application/PlaceService.java
+++ b/src/main/java/com/adregamdi/place/application/PlaceService.java
@@ -54,4 +54,9 @@ public interface PlaceService {
      * [일정에 많이 추가된 장소 리스트 조회]
      * */
     GetPopularPlacesResponse getPopularPlaces(final Long lastId, final Integer lastAddCount);
+
+    /*
+     * [내 리뷰 조회]
+     * */
+    GetMyPlaceReviewResponse getReview(final String username);
 }

--- a/src/main/java/com/adregamdi/place/dto/MyPlaceReviewDTO.java
+++ b/src/main/java/com/adregamdi/place/dto/MyPlaceReviewDTO.java
@@ -1,0 +1,19 @@
+package com.adregamdi.place.dto;
+
+import com.adregamdi.place.domain.PlaceReviewImage;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record MyPlaceReviewDTO(
+        String title,
+        String contentsLabel,
+        String regionLabel,
+        Integer imageReviewCount,
+        Integer shortsReviewCount,
+        String travelDate,
+        String content,
+        List<PlaceReviewImage> placeReviewImageList,
+        LocalDate createdAt
+) {
+}

--- a/src/main/java/com/adregamdi/place/dto/MyPlaceReviewDTO.java
+++ b/src/main/java/com/adregamdi/place/dto/MyPlaceReviewDTO.java
@@ -1,10 +1,12 @@
 package com.adregamdi.place.dto;
 
 import com.adregamdi.place.domain.PlaceReviewImage;
+import lombok.Builder;
 
 import java.time.LocalDate;
 import java.util.List;
 
+@Builder
 public record MyPlaceReviewDTO(
         String title,
         String contentsLabel,
@@ -16,4 +18,27 @@ public record MyPlaceReviewDTO(
         List<PlaceReviewImage> placeReviewImageList,
         LocalDate createdAt
 ) {
+    public static MyPlaceReviewDTO of(
+            final String title,
+            final String contentsLabel,
+            final String regionLabel,
+            final Integer imageReviewCount,
+            final Integer shortsReviewCount,
+            final String travelDate,
+            final String content,
+            final List<PlaceReviewImage> placeReviewImageList,
+            final LocalDate createdAt
+    ) {
+        return MyPlaceReviewDTO.builder()
+                .title(title)
+                .contentsLabel(contentsLabel)
+                .regionLabel(regionLabel)
+                .imageReviewCount(imageReviewCount)
+                .shortsReviewCount(shortsReviewCount)
+                .travelDate(travelDate)
+                .content(content)
+                .placeReviewImageList(placeReviewImageList)
+                .createdAt(createdAt)
+                .build();
+    }
 }

--- a/src/main/java/com/adregamdi/place/dto/response/GetMyPlaceReviewResponse.java
+++ b/src/main/java/com/adregamdi/place/dto/response/GetMyPlaceReviewResponse.java
@@ -1,4 +1,17 @@
 package com.adregamdi.place.dto.response;
 
-public record GetMyPlaceReviewResponse() {
+import com.adregamdi.place.dto.MyPlaceReviewDTO;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GetMyPlaceReviewResponse(
+        List<MyPlaceReviewDTO> review_list
+) {
+    public static GetMyPlaceReviewResponse from(final List<MyPlaceReviewDTO> myPlaceReviewDTOs) {
+        return GetMyPlaceReviewResponse.builder()
+                .review_list(myPlaceReviewDTOs)
+                .build();
+    }
 }

--- a/src/main/java/com/adregamdi/place/dto/response/GetMyPlaceReviewResponse.java
+++ b/src/main/java/com/adregamdi/place/dto/response/GetMyPlaceReviewResponse.java
@@ -1,0 +1,4 @@
+package com.adregamdi.place.dto.response;
+
+public record GetMyPlaceReviewResponse() {
+}

--- a/src/main/java/com/adregamdi/place/infrastructure/PlaceRepository.java
+++ b/src/main/java/com/adregamdi/place/infrastructure/PlaceRepository.java
@@ -3,6 +3,7 @@ package com.adregamdi.place.infrastructure;
 import com.adregamdi.place.domain.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -13,4 +14,20 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceCustom
 
     @Query("SELECT COUNT(p) FROM Place p")
     long countTotalPlaces();
+
+    @Query("""
+            SELECT COUNT(DISTINCT pr.placeReviewId)
+            FROM PlaceReview pr
+            JOIN PlaceReviewImage pri
+            ON pr.placeReviewId = pri.placeReviewId
+            WHERE pr.placeId = :placeId
+            """)
+    int countPlaceReviewsWithImagesForPlace(@Param("placeId") Long placeId);
+
+    @Query("""
+            SELECT COUNT(s)
+            FROM Shorts s
+            WHERE s.placeId = :placeId
+            """)
+    int countShortsReviewsForPlace(@Param("placeId") Long placeId);
 }

--- a/src/main/java/com/adregamdi/place/infrastructure/PlaceReviewImageRepository.java
+++ b/src/main/java/com/adregamdi/place/infrastructure/PlaceReviewImageRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PlaceReviewImageRepository extends JpaRepository<PlaceReviewImage, Long> {
-    Optional<List<PlaceReviewImage>> findByPlaceReviewId(final Long placeReviewId);
+    Optional<List<PlaceReviewImage>> findAllByPlaceReviewId(Long placeReviewId);
 }

--- a/src/main/java/com/adregamdi/place/infrastructure/PlaceReviewRepository.java
+++ b/src/main/java/com/adregamdi/place/infrastructure/PlaceReviewRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> {
-    Optional<List<PlaceReview>> findByTravelogueId(final Long travelogueId);
+    Optional<List<PlaceReview>> findAllByTravelogueId(Long travelogueId);
+
+    Optional<List<PlaceReview>> findAllByMemberIdOrderByPlaceReviewIdDesc(UUID memberId);
 
     int countByPlaceId(Long placeId);
 }

--- a/src/main/java/com/adregamdi/place/presentation/PlaceController.java
+++ b/src/main/java/com/adregamdi/place/presentation/PlaceController.java
@@ -126,4 +126,15 @@ public class PlaceController {
                         .build()
                 );
     }
+
+    @GetMapping("/review")
+    @MemberAuthorize
+    public ResponseEntity<ApiResponse<GetMyPlaceReviewResponse>> getReview(@AuthenticationPrincipal final UserDetails userDetails) {
+        return ResponseEntity.ok()
+                .body(ApiResponse.<GetMyPlaceReviewResponse>builder()
+                        .statusCode(HttpStatus.OK.value())
+                        .data(placeService.getReview(userDetails.getUsername()))
+                        .build()
+                );
+    }
 }

--- a/src/main/java/com/adregamdi/travel/infrastructure/TravelPlaceRepository.java
+++ b/src/main/java/com/adregamdi/travel/infrastructure/TravelPlaceRepository.java
@@ -11,4 +11,6 @@ public interface TravelPlaceRepository extends JpaRepository<TravelPlace, Long>,
     List<TravelPlace> findAllByTravelDayId(Long travelDayId);
 
     void deleteAllByTravelDayId(Long travelDayId);
+
+    void deleteByTravelDayIdAndPlaceId(Long travelDayId, Long placeId);
 }

--- a/src/main/java/com/adregamdi/travelogue/application/TravelogueService.java
+++ b/src/main/java/com/adregamdi/travelogue/application/TravelogueService.java
@@ -180,7 +180,7 @@ public class TravelogueService {
                 .orElseThrow(() -> new PlaceReviewNotFoundException(travelogueId));
 
         Function<Long, List<PlaceReviewImage>> placeReviewImagesFetcher = (reviewId) ->
-                placeReviewImageRepository.findByPlaceReviewId(reviewId)
+                placeReviewImageRepository.findAllByPlaceReviewId(reviewId)
                         .orElseThrow(() -> new PlaceReviewImageNotFoundException(reviewId));
 
         return GetTravelogueResponse.of(travelogue, travelogueImages, travelogueDays, placeReviews, placeReviewImagesFetcher);

--- a/src/main/java/com/adregamdi/travelogue/application/TravelogueService.java
+++ b/src/main/java/com/adregamdi/travelogue/application/TravelogueService.java
@@ -176,7 +176,7 @@ public class TravelogueService {
         List<TravelogueDay> travelogueDays = travelogueDayRepository.findByTravelogueIdOrderByDay(travelogueId)
                 .orElseThrow(() -> new TravelogueDayNotFoundException(travelogueId));
 
-        List<PlaceReview> placeReviews = placeReviewRepository.findByTravelogueId(travelogueId)
+        List<PlaceReview> placeReviews = placeReviewRepository.findAllByTravelogueId(travelogueId)
                 .orElseThrow(() -> new PlaceReviewNotFoundException(travelogueId));
 
         Function<Long, List<PlaceReviewImage>> placeReviewImagesFetcher = (reviewId) ->


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #104 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- 내 리뷰 조회 API

- 회원 정보 수정 API
  - 이름 수정 기능 제거
  - 닉네임 중복 체크 로직 수정

- 일정에서 장소 추가/삭제 시 버그 수정

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/b98f15a6-8d30-432f-94eb-fb613fab9103)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
JPA를 사용해서 컬렉션 반환 시 Optional을 사용하지 않는 이유
- 데이터 없으면 어차피 빈 컬렉션으로 리턴됨.
- 즉, NPE가 발생하지 않음.
- Optional로 감싸는 것은 추가적인 객체 생성을 의미하며, 이는 미세한 성능 오버헤드 발생.
- 따라서 대량의 데이터를 다루는 경우 이러한 오버헤드가 누적될 수 있음.

그럼에도 불구하고 내가 사용한 이유: 
- 원 데이터의 특정 값으로 다른 데이터를 조회하는 경우가 있는데 이때 원 데이터들의 컬렉션이 빈 컬렉션이면 에러남.
- 그러므로 데이터 없으면 예외 처리를 통해 즉시 프론트로 에러 코드를 반환시키기 위해서 Optional 사용.