### PR TITLE
Feature - 애플 로그인 구현 외

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     // 애플 로그인을 위한 라이브러리
     implementation 'com.auth0:jwks-rsa:0.21.1'
-    implementation 'org.json:json:20210307'
-    implementation 'org.bouncycastle:bcprov-jdk15on'
+    implementation 'org.json:json:20231013'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
 
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    // 애플 로그인을 위한 라이브러리
+    implementation 'com.auth0:jwks-rsa:0.21.1'
+    implementation 'org.json:json:20210307'
+    implementation 'org.bouncycastle:bcprov-jdk15on'
 
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
@@ -67,7 +71,6 @@ dependencies {
 
     // 썸네일 제작을 위한 라이브러리
     implementation 'org.bytedeco:javacv-platform:1.5.9'
-
 }
 
 tasks.named('test') {
@@ -94,7 +97,7 @@ clean {
 
 //// submodule 폴더 내 변동사항 현 플젝에 적용 task
 task copyPrivate(type: Copy) {
-    copy{
+    copy {
         from './BackEnd-Config'
         into 'src/main/resources'
     }

--- a/src/main/generated/com/adregamdi/like/domain/QLike.java
+++ b/src/main/generated/com/adregamdi/like/domain/QLike.java
@@ -19,15 +19,21 @@ public class QLike extends EntityPathBase<Like> {
 
     public static final QLike like = new QLike("like1");
 
+    public final com.adregamdi.core.entity.QBaseTime _super = new com.adregamdi.core.entity.QBaseTime(this);
+
     public final NumberPath<Long> contentId = createNumber("contentId", Long.class);
 
     public final EnumPath<com.adregamdi.like.domain.enumtype.ContentType> contentType = createEnum("contentType", com.adregamdi.like.domain.enumtype.ContentType.class);
 
-    public final DateTimePath<java.time.LocalDateTime> createAt = createDateTime("createAt", java.time.LocalDateTime.class);
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 
     public final NumberPath<Long> likeId = createNumber("likeId", Long.class);
 
     public final ComparablePath<java.util.UUID> memberId = createComparable("memberId", java.util.UUID.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
 
     public QLike(String variable) {
         super(Like.class, forVariable(variable));

--- a/src/main/generated/com/adregamdi/like/domain/QLike.java
+++ b/src/main/generated/com/adregamdi/like/domain/QLike.java
@@ -30,7 +30,7 @@ public class QLike extends EntityPathBase<Like> {
 
     public final NumberPath<Long> likeId = createNumber("likeId", Long.class);
 
-    public final ComparablePath<java.util.UUID> memberId = createComparable("memberId", java.util.UUID.class);
+    public final StringPath memberId = createString("memberId");
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;

--- a/src/main/generated/com/adregamdi/media/domain/QImage.java
+++ b/src/main/generated/com/adregamdi/media/domain/QImage.java
@@ -19,7 +19,10 @@ public class QImage extends EntityPathBase<Image> {
 
     public static final QImage image = new QImage("image");
 
-    public final DateTimePath<java.time.LocalDateTime> createDate = createDateTime("createDate", java.time.LocalDateTime.class);
+    public final com.adregamdi.core.entity.QBaseTime _super = new com.adregamdi.core.entity.QBaseTime(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 
     public final NumberPath<Long> imageNo = createNumber("imageNo", Long.class);
 
@@ -28,6 +31,9 @@ public class QImage extends EntityPathBase<Image> {
     public final StringPath imageUrl = createString("imageUrl");
 
     public final StringPath targetId = createString("targetId");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
 
     public QImage(String variable) {
         super(Image.class, forVariable(variable));

--- a/src/main/generated/com/adregamdi/notification/domain/QNotification.java
+++ b/src/main/generated/com/adregamdi/notification/domain/QNotification.java
@@ -28,7 +28,7 @@ public class QNotification extends EntityPathBase<Notification> {
 
     public final BooleanPath isRead = createBoolean("isRead");
 
-    public final ComparablePath<java.util.UUID> memberId = createComparable("memberId", java.util.UUID.class);
+    public final StringPath memberId = createString("memberId");
 
     public final NumberPath<Long> notificationId = createNumber("notificationId", Long.class);
 

--- a/src/main/generated/com/adregamdi/place/domain/QPlaceReview.java
+++ b/src/main/generated/com/adregamdi/place/domain/QPlaceReview.java
@@ -26,7 +26,7 @@ public class QPlaceReview extends EntityPathBase<PlaceReview> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 
-    public final ComparablePath<java.util.UUID> memberId = createComparable("memberId", java.util.UUID.class);
+    public final StringPath memberId = createString("memberId");
 
     public final NumberPath<Long> placeId = createNumber("placeId", Long.class);
 

--- a/src/main/generated/com/adregamdi/shorts/domain/QShorts.java
+++ b/src/main/generated/com/adregamdi/shorts/domain/QShorts.java
@@ -26,7 +26,7 @@ public class QShorts extends EntityPathBase<Shorts> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 
-    public final ComparablePath<java.util.UUID> memberId = createComparable("memberId", java.util.UUID.class);
+    public final StringPath memberId = createString("memberId");
 
     public final NumberPath<Long> placeId = createNumber("placeId", Long.class);
 

--- a/src/main/generated/com/adregamdi/travel/domain/QTravel.java
+++ b/src/main/generated/com/adregamdi/travel/domain/QTravel.java
@@ -26,7 +26,7 @@ public class QTravel extends EntityPathBase<Travel> {
 
     public final DatePath<java.time.LocalDate> endDate = createDate("endDate", java.time.LocalDate.class);
 
-    public final ComparablePath<java.util.UUID> memberId = createComparable("memberId", java.util.UUID.class);
+    public final StringPath memberId = createString("memberId");
 
     public final DatePath<java.time.LocalDate> startDate = createDate("startDate", java.time.LocalDate.class);
 

--- a/src/main/generated/com/adregamdi/travelogue/domain/QTravelogue.java
+++ b/src/main/generated/com/adregamdi/travelogue/domain/QTravelogue.java
@@ -26,7 +26,7 @@ public class QTravelogue extends EntityPathBase<Travelogue> {
 
     public final StringPath introduction = createString("introduction");
 
-    public final ComparablePath<java.util.UUID> memberId = createComparable("memberId", java.util.UUID.class);
+    public final StringPath memberId = createString("memberId");
 
     public final StringPath title = createString("title");
 

--- a/src/main/java/com/adregamdi/core/config/SecurityConfig.java
+++ b/src/main/java/com/adregamdi/core/config/SecurityConfig.java
@@ -2,9 +2,9 @@ package com.adregamdi.core.config;
 
 import com.adregamdi.core.jwt.filter.JwtAuthenticationFilter;
 import com.adregamdi.core.jwt.service.JwtService;
+import com.adregamdi.core.oauth2.application.CustomOAuth2UserService;
 import com.adregamdi.core.oauth2.handler.OAuth2LoginFailureHandler;
 import com.adregamdi.core.oauth2.handler.OAuth2LoginSuccessHandler;
-import com.adregamdi.core.oauth2.service.CustomOAuth2UserService;
 import com.adregamdi.member.infrastructure.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/adregamdi/core/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/adregamdi/core/handler/GlobalExceptionHandler.java
@@ -113,6 +113,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(value = {
             MemberException.HandleExistException.class,
             PlaceException.PlaceExistException.class,
+            PlaceException.PlaceReviewExistException.class,
             ShortsException.ShortsExistException.class,
             TravelogueException.TravelogueExistException.class
     })

--- a/src/main/java/com/adregamdi/core/oauth2/application/AppleOAuth2UserInfo.java
+++ b/src/main/java/com/adregamdi/core/oauth2/application/AppleOAuth2UserInfo.java
@@ -1,4 +1,4 @@
-package com.adregamdi.core.oauth2.service;
+package com.adregamdi.core.oauth2.application;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/com/adregamdi/core/oauth2/application/CustomOAuth2UserService.java
+++ b/src/main/java/com/adregamdi/core/oauth2/application/CustomOAuth2UserService.java
@@ -1,4 +1,4 @@
-package com.adregamdi.core.oauth2.service;
+package com.adregamdi.core.oauth2.application;
 
 
 import com.adregamdi.core.oauth2.domain.CustomOAuth2User;

--- a/src/main/java/com/adregamdi/core/oauth2/application/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/adregamdi/core/oauth2/application/GoogleOAuth2UserInfo.java
@@ -1,4 +1,4 @@
-package com.adregamdi.core.oauth2.service;
+package com.adregamdi.core.oauth2.application;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/com/adregamdi/core/oauth2/application/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/adregamdi/core/oauth2/application/KakaoOAuth2UserInfo.java
@@ -1,4 +1,4 @@
-package com.adregamdi.core.oauth2.service;
+package com.adregamdi.core.oauth2.application;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/com/adregamdi/core/oauth2/application/OAuth2Service.java
+++ b/src/main/java/com/adregamdi/core/oauth2/application/OAuth2Service.java
@@ -4,7 +4,6 @@ import com.adregamdi.core.jwt.service.JwtService;
 import com.adregamdi.core.oauth2.dto.LoginRequest;
 import com.adregamdi.core.oauth2.dto.LoginResponse;
 import com.adregamdi.core.oauth2.dto.OAuth2Attributes;
-import com.adregamdi.media.application.ImageService;
 import com.adregamdi.member.domain.Member;
 import com.adregamdi.member.domain.SocialType;
 import com.adregamdi.member.infrastructure.MemberRepository;
@@ -35,8 +34,6 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.*;
 
-import static com.adregamdi.media.domain.ImageTarget.PROFILE;
-
 
 @Slf4j
 @RequiredArgsConstructor
@@ -45,7 +42,6 @@ public class OAuth2Service {
     private static final String APPLE = "apple";
     private static final String KAKAO = "kakao";
     private final JwtService jwtService;
-    private final ImageService imageService;
     private final MemberRepository memberRepository;
     private final WebClient webClient;
 
@@ -305,7 +301,6 @@ public class OAuth2Service {
 
     private Member saveMember(final OAuth2Attributes attributes, final SocialType socialType) {
         Member createdMember = attributes.toEntity(socialType, attributes.getOauth2UserInfo());
-        imageService.saveTargetId(createdMember.getProfile(), PROFILE, String.valueOf(createdMember.getMemberId()));
         return memberRepository.save(createdMember);
     }
 }

--- a/src/main/java/com/adregamdi/core/oauth2/application/OAuth2Service.java
+++ b/src/main/java/com/adregamdi/core/oauth2/application/OAuth2Service.java
@@ -4,6 +4,7 @@ import com.adregamdi.core.jwt.service.JwtService;
 import com.adregamdi.core.oauth2.dto.LoginRequest;
 import com.adregamdi.core.oauth2.dto.LoginResponse;
 import com.adregamdi.core.oauth2.dto.OAuth2Attributes;
+import com.adregamdi.media.application.ImageService;
 import com.adregamdi.member.domain.Member;
 import com.adregamdi.member.domain.SocialType;
 import com.adregamdi.member.infrastructure.MemberRepository;
@@ -34,6 +35,8 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.*;
 
+import static com.adregamdi.media.domain.ImageTarget.PROFILE;
+
 
 @Slf4j
 @RequiredArgsConstructor
@@ -42,6 +45,7 @@ public class OAuth2Service {
     private static final String APPLE = "apple";
     private static final String KAKAO = "kakao";
     private final JwtService jwtService;
+    private final ImageService imageService;
     private final MemberRepository memberRepository;
     private final WebClient webClient;
 
@@ -301,6 +305,7 @@ public class OAuth2Service {
 
     private Member saveMember(final OAuth2Attributes attributes, final SocialType socialType) {
         Member createdMember = attributes.toEntity(socialType, attributes.getOauth2UserInfo());
+        imageService.saveTargetId(createdMember.getProfile(), PROFILE, String.valueOf(createdMember.getMemberId()));
         return memberRepository.save(createdMember);
     }
 }

--- a/src/main/java/com/adregamdi/core/oauth2/application/OAuth2Service.java
+++ b/src/main/java/com/adregamdi/core/oauth2/application/OAuth2Service.java
@@ -1,4 +1,4 @@
-package com.adregamdi.core.oauth2.service;
+package com.adregamdi.core.oauth2.application;
 
 import com.adregamdi.core.jwt.service.JwtService;
 import com.adregamdi.core.oauth2.dto.LoginRequest;

--- a/src/main/java/com/adregamdi/core/oauth2/application/OAuth2UserInfo.java
+++ b/src/main/java/com/adregamdi/core/oauth2/application/OAuth2UserInfo.java
@@ -1,4 +1,4 @@
-package com.adregamdi.core.oauth2.service;
+package com.adregamdi.core.oauth2.application;
 
 import java.util.Map;
 

--- a/src/main/java/com/adregamdi/core/oauth2/dto/LoginRequest.java
+++ b/src/main/java/com/adregamdi/core/oauth2/dto/LoginRequest.java
@@ -4,8 +4,9 @@ import jakarta.validation.constraints.NotBlank;
 
 public record LoginRequest(
         @NotBlank
+        String socialType,
         String oauthAccessToken,
-        @NotBlank
-        String socialType
+        String authorizationCode,
+        String idToken
 ) {
 }

--- a/src/main/java/com/adregamdi/core/oauth2/dto/OAuth2Attributes.java
+++ b/src/main/java/com/adregamdi/core/oauth2/dto/OAuth2Attributes.java
@@ -77,6 +77,7 @@ public class OAuth2Attributes {
     ) {
         String uuid = String.valueOf(UUID.randomUUID());
         String name = "미지정";
+        String profile = "https://adregamdi-dev2.s3.ap-northeast-2.amazonaws.com/profile/default_profile_image.png";
         String handle = uuid + "-ad";
         String email = uuid + "@adregamdi.com";
         String age = "Unknown";
@@ -106,16 +107,15 @@ public class OAuth2Attributes {
             name = oauth2UserInfo.getName();
         }
 
-        SignUpDTO signUpDTO = new SignUpDTO(
-                name,
-                handle,
-                email,
-                age,
-                gender,
-                oauth2UserInfo.getId(),
-                socialType
-        );
-
-        return new Member(signUpDTO);
+        return Member.builder()
+                .name(name)
+                .profile(profile)
+                .handle(handle)
+                .email(email)
+                .age(age)
+                .gender(gender)
+                .socialId(oauth2UserInfo.getId())
+                .socialType(socialType)
+                .build();
     }
 }

--- a/src/main/java/com/adregamdi/core/oauth2/dto/OAuth2Attributes.java
+++ b/src/main/java/com/adregamdi/core/oauth2/dto/OAuth2Attributes.java
@@ -1,9 +1,9 @@
 package com.adregamdi.core.oauth2.dto;
 
-import com.adregamdi.core.oauth2.service.AppleOAuth2UserInfo;
-import com.adregamdi.core.oauth2.service.GoogleOAuth2UserInfo;
-import com.adregamdi.core.oauth2.service.KakaoOAuth2UserInfo;
-import com.adregamdi.core.oauth2.service.OAuth2UserInfo;
+import com.adregamdi.core.oauth2.application.AppleOAuth2UserInfo;
+import com.adregamdi.core.oauth2.application.GoogleOAuth2UserInfo;
+import com.adregamdi.core.oauth2.application.KakaoOAuth2UserInfo;
+import com.adregamdi.core.oauth2.application.OAuth2UserInfo;
 import com.adregamdi.member.domain.Member;
 import com.adregamdi.member.domain.SocialType;
 import lombok.Builder;

--- a/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
+++ b/src/main/java/com/adregamdi/core/oauth2/presentation/OAuth2Controller.java
@@ -1,9 +1,9 @@
 package com.adregamdi.core.oauth2.presentation;
 
 import com.adregamdi.core.handler.ApiResponse;
+import com.adregamdi.core.oauth2.application.OAuth2Service;
 import com.adregamdi.core.oauth2.dto.LoginRequest;
 import com.adregamdi.core.oauth2.dto.LoginResponse;
-import com.adregamdi.core.oauth2.service.OAuth2Service;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/adregamdi/like/application/LikesService.java
+++ b/src/main/java/com/adregamdi/like/application/LikesService.java
@@ -16,8 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.UUID;
-
 @Slf4j
 @Service
 @Transactional
@@ -30,13 +28,13 @@ public class LikesService {
     public CreateLikesResponse create(String memberId, CreateLikesRequest request) {
 
         boolean isLiked = likesRepository.findByContentTypeAndContentId(request.getContentType(), request.contentId()).isPresent();
-        if(isLiked) {
+        if (isLiked) {
             return new CreateLikesResponse(true);
         }
 
 
         Like like = Like.builder()
-                .memberId(UUID.fromString(memberId))
+                .memberId(memberId)
                 .contentType(request.getContentType())
                 .contentId(request.contentId())
                 .build();
@@ -47,7 +45,7 @@ public class LikesService {
     public CreateShortsLikeResponse createShortsLike(String memberId, Long shortsId) {
 
         Like like = Like.builder()
-                .memberId(UUID.fromString(memberId))
+                .memberId(memberId)
                 .contentType(ContentType.SHORTS)
                 .contentId(shortsId)
                 .build();
@@ -67,7 +65,7 @@ public class LikesService {
 
         if (memberRole == Role.ADMIN) {
             log.info("관리자 권한으로 좋아요를 삭제합니다. 좋아요 ID: {}", like.getLikeId());
-        } else if (!likesValidService.isWriter(like.getMemberId().toString(), memberId)) {
+        } else if (!likesValidService.isWriter(like.getMemberId(), memberId)) {
             log.warn("작성자 외에 요청으로 인해 메서드를 종료합니다.");
             return;
         }
@@ -87,7 +85,7 @@ public class LikesService {
     }
 
     @Transactional(readOnly = true)
-    public Boolean checkIsLiked(UUID memberId, ContentType contentType, Long contentId) {
+    public Boolean checkIsLiked(String memberId, ContentType contentType, Long contentId) {
 
         return likesRepository.checkIsLiked(memberId, contentType, contentId);
     }

--- a/src/main/java/com/adregamdi/like/domain/Like.java
+++ b/src/main/java/com/adregamdi/like/domain/Like.java
@@ -9,8 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
-import java.util.UUID;
-
 @Entity
 @Getter
 @NoArgsConstructor
@@ -27,9 +25,9 @@ public class Like extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long likeId;
 
-    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "CHAR(36)")
+    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "VARCHAR(36)")
     @Comment("회원 id")
-    private UUID memberId;
+    private String memberId;
 
     @Column(name = "content_type", nullable = false)
     @Comment("컨텐츠 타입")
@@ -41,7 +39,7 @@ public class Like extends BaseTime {
     private Long contentId;
 
     @Builder
-    public Like(UUID memberId, ContentType contentType, Long contentId) {
+    public Like(String memberId, ContentType contentType, Long contentId) {
         this.memberId = memberId;
         this.contentType = contentType;
         this.contentId = contentId;

--- a/src/main/java/com/adregamdi/like/domain/Like.java
+++ b/src/main/java/com/adregamdi/like/domain/Like.java
@@ -1,5 +1,6 @@
 package com.adregamdi.like.domain;
 
+import com.adregamdi.core.entity.BaseTime;
 import com.adregamdi.like.domain.enumtype.ContentType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -7,9 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
-import org.hibernate.annotations.CreationTimestamp;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -19,16 +18,16 @@ import java.util.UUID;
 @Table(name = "tbl_like",
         uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "content_type", "content_id"}),
         indexes = {
-        @Index(name = "idx_member_content", columnList = "memberId, contentType, contentId"),
-        @Index(name = "idx_content", columnList = "contentType, contentId")
-})
-public class Like {
+                @Index(name = "idx_member_content", columnList = "memberId, contentType, contentId"),
+                @Index(name = "idx_content", columnList = "contentType, contentId")
+        })
+public class Like extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long likeId;
 
-    @Column(name = "member_id", updatable = false, nullable = false)
+    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "CHAR(36)")
     @Comment("회원 id")
     private UUID memberId;
 
@@ -41,17 +40,11 @@ public class Like {
     @Comment("컨텐츠 id")
     private Long contentId;
 
-    @Column(name = "create_at", updatable = false)
-    @Comment("생성 시간")
-    @CreationTimestamp
-    private LocalDateTime createAt;
-
     @Builder
-    public Like(UUID memberId, ContentType contentType, Long contentId, LocalDateTime createAt) {
+    public Like(UUID memberId, ContentType contentType, Long contentId) {
         this.memberId = memberId;
         this.contentType = contentType;
         this.contentId = contentId;
-        this.createAt = createAt;
     }
 
 }

--- a/src/main/java/com/adregamdi/like/infrastructure/LikesCustomRepository.java
+++ b/src/main/java/com/adregamdi/like/infrastructure/LikesCustomRepository.java
@@ -8,7 +8,6 @@ import com.adregamdi.like.dto.request.GetLikesContentsRequest;
 import com.adregamdi.like.dto.response.GetLikesContentsResponse;
 
 import java.util.List;
-import java.util.UUID;
 
 public interface LikesCustomRepository {
 
@@ -20,5 +19,5 @@ public interface LikesCustomRepository {
 
     GetLikesContentsResponse<?> getLikesContentsOfTravelogue(GetLikesContentsRequest request);
 
-    Boolean checkIsLiked(UUID memberId, ContentType contentType, Long contentId);
+    Boolean checkIsLiked(String memberId, ContentType contentType, Long contentId);
 }

--- a/src/main/java/com/adregamdi/like/infrastructure/LikesCustomRepositoryImpl.java
+++ b/src/main/java/com/adregamdi/like/infrastructure/LikesCustomRepositoryImpl.java
@@ -20,7 +20,6 @@ import org.springframework.stereotype.Repository;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.adregamdi.like.domain.QLike.like;
@@ -35,7 +34,7 @@ import static com.adregamdi.travelogue.domain.QTravelogueImage.travelogueImage;
 @Slf4j
 @Repository
 @RequiredArgsConstructor
-public class LikesCustomRepositoryImpl implements LikesCustomRepository{
+public class LikesCustomRepositoryImpl implements LikesCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
@@ -68,7 +67,7 @@ public class LikesCustomRepositoryImpl implements LikesCustomRepository{
                 .leftJoin(place).on(like.contentId.eq(place.placeId).and(like.contentType.eq(ContentType.PLACE)))
                 .leftJoin(travelogue).on(like.contentId.eq(travelogue.travelogueId).and(like.contentType.eq(ContentType.TRAVELOGUE)))
                 .where(
-                        like.memberId.eq(UUID.fromString(request.memberId())),
+                        like.memberId.eq(request.memberId()),
                         like.likeId.lt(request.lastLikeId()))
                 .orderBy(like.likeId.desc())
                 .limit(request.size() + 1)
@@ -112,7 +111,7 @@ public class LikesCustomRepositoryImpl implements LikesCustomRepository{
                                 JPAExpressions
                                         .selectOne()
                                         .from(like)
-                                        .where(like.memberId.eq(UUID.fromString(request.memberId()))
+                                        .where(like.memberId.eq(request.memberId())
                                                 .and(like.contentType.eq(ContentType.SHORTS))
                                                 .and(like.contentId.eq(shorts.shortsId)))
                                         .exists(),
@@ -120,11 +119,11 @@ public class LikesCustomRepositoryImpl implements LikesCustomRepository{
                         )))
                 .from(like)
                 .join(shorts).on(like.contentId.eq(shorts.shortsId).and(like.contentType.eq(ContentType.SHORTS)))
-                .join(member).on(shorts.memberId.eq(member.memberId))
+                .join(member).on(shorts.memberId.eq(String.valueOf(member.memberId)))
                 .leftJoin(place).on(shorts.placeId.eq(place.placeId))
                 .leftJoin(travelogue).on(shorts.travelogueId.eq(travelogue.travelogueId))
                 .where(
-                        like.memberId.eq(UUID.fromString(request.memberId())),
+                        like.memberId.eq(request.memberId()),
                         like.contentType.eq(ContentType.SHORTS),
                         shorts.assignedStatus.eq(true),
                         like.likeId.lt(request.lastLikeId())
@@ -148,9 +147,9 @@ public class LikesCustomRepositoryImpl implements LikesCustomRepository{
                 .select(travelogue.travelogueId, travelogue.title, member.name, member.profile)
                 .from(like)
                 .leftJoin(travelogue).on(like.contentId.eq(travelogue.travelogueId).and(like.contentType.eq(ContentType.TRAVELOGUE)))
-                .leftJoin(member).on(travelogue.memberId.eq(member.memberId))
+                .leftJoin(member).on(travelogue.memberId.eq(String.valueOf(member.memberId)))
                 .where(
-                        like.memberId.eq(UUID.fromString(request.memberId())),
+                        like.memberId.eq(request.memberId()),
                         like.contentType.eq(ContentType.TRAVELOGUE),
                         like.likeId.lt(request.lastLikeId())
                 )
@@ -201,7 +200,7 @@ public class LikesCustomRepositoryImpl implements LikesCustomRepository{
                 .from(like)
                 .join(place).on(like.contentId.eq(place.placeId).and(like.contentType.eq(ContentType.PLACE)))
                 .where(
-                        like.memberId.eq(UUID.fromString(request.memberId())),
+                        like.memberId.eq(request.memberId()),
                         like.contentType.eq(ContentType.PLACE),
                         like.likeId.lt(request.lastLikeId())
                 )
@@ -264,7 +263,7 @@ public class LikesCustomRepositoryImpl implements LikesCustomRepository{
     }
 
     @Override
-    public Boolean checkIsLiked(UUID memberId, ContentType contentType, Long contentId) {
+    public Boolean checkIsLiked(String memberId, ContentType contentType, Long contentId) {
         return jpaQueryFactory
                 .selectFrom(like)
                 .where(like.memberId.eq(memberId)

--- a/src/main/java/com/adregamdi/media/application/ImageServiceImpl.java
+++ b/src/main/java/com/adregamdi/media/application/ImageServiceImpl.java
@@ -26,11 +26,10 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class ImageServiceImpl implements ImageService {
 
+    private final static int IMAGE_RESIZE_TARGET_WIDTH = 650;
     private final FileUploadService fileUploadService;
     private final ImageValidService imageValidService;
     private final ImageRepository imageRepository;
-
-    private final static int IMAGE_RESIZE_TARGET_WIDTH = 650;
 
     private Image getImageByImageUrl(String imageUrl) {
         Image image = imageRepository.findImageByImageUrl(imageUrl)
@@ -117,9 +116,14 @@ public class ImageServiceImpl implements ImageService {
         String filename = imageValidService.getFileNameFromUrl(imageUrl);
         imageValidService.checkImageFile(filename);
 
-        Image image = getImageByImageUrl(imageUrl);
-        image.updateImageTarget(imageTarget);
-        image.updateTargetId(targetId);
+//        Image image = getImageByImageUrl(imageUrl);
+//        image.updateImageTarget(imageTarget);
+//        image.updateTargetId(targetId);
+        Image image = imageRepository.save(Image.builder()
+                .imageUrl(imageUrl)
+                .imageTarget(imageTarget)
+                .targetId(targetId)
+                .build());
         log.info("{} 번의 이미지가 {} 의 {} 번의 엔테티로 할당되었습니다,", image.getImageNo(), image.getImageTarget(), image.getTargetId());
     }
 

--- a/src/main/java/com/adregamdi/media/domain/Image.java
+++ b/src/main/java/com/adregamdi/media/domain/Image.java
@@ -1,18 +1,17 @@
 package com.adregamdi.media.domain;
 
+import com.adregamdi.core.entity.BaseTime;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Getter
 @NoArgsConstructor
 @Table(name = "tbl_image")
-public class Image {
+public class Image extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,18 +31,12 @@ public class Image {
     @Comment(value = "관련 엔티티 식별 값")
     private String targetId;
 
-    @Column(name = "create_date", updatable = false)
-    @Comment(value = "이미지 생성일")
-    private LocalDateTime createDate;
-
-
     @Builder
     public Image(Long imageNo, String imageUrl, ImageTarget imageTarget, String targetId) {
         this.imageNo = imageNo;
         this.imageUrl = imageUrl;
         this.imageTarget = imageTarget;
         this.targetId = targetId;
-        this.createDate = LocalDateTime.now();
     }
 
     public void updateTargetId(String targetId) {

--- a/src/main/java/com/adregamdi/media/infrastructure/ImageRepository.java
+++ b/src/main/java/com/adregamdi/media/infrastructure/ImageRepository.java
@@ -19,7 +19,7 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
     List<Image> findByImageUrlIn(List<String> imageUrls);
 
-    @Query("SELECT i.imageUrl FROM Image i WHERE i.targetId IS NULL AND i.createDate < :date")
+    @Query("SELECT i.imageUrl FROM Image i WHERE i.targetId IS NULL AND i.createdAt < :date")
     List<String> findUnassignedImagesBeforeDate(@Param("date") LocalDateTime date);
 
     @Query("DELETE FROM Image i WHERE i.imageUrl IN :imageUrls")

--- a/src/main/java/com/adregamdi/member/application/MemberService.java
+++ b/src/main/java/com/adregamdi/member/application/MemberService.java
@@ -58,7 +58,7 @@ public class MemberService {
             throw new HandleExistException(request.handle());
         }
 
-        member.updateMember(request.profile(), request.name(), request.handle());
+        member.updateMember(request.name(), request.profile(), request.handle());
         imageService.updateImage(request.profile(), PROFILE, memberId);
     }
 

--- a/src/main/java/com/adregamdi/member/application/MemberService.java
+++ b/src/main/java/com/adregamdi/member/application/MemberService.java
@@ -49,17 +49,17 @@ public class MemberService {
      * [내 정보 수정]
      */
     @Transactional
-    public void update(final UpdateMyMemberRequest request, final String username) {
+    public void update(final UpdateMyMemberRequest request, final String memberId) {
         Member another = memberRepository.findByHandle(request.handle());
-        Member member = memberRepository.findById(UUID.fromString(username))
-                .orElseThrow(() -> new MemberNotFoundException(username));
+        Member member = memberRepository.findById(UUID.fromString(memberId))
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
 
         if (another != null && !Objects.equals(another.getHandle(), member.getHandle())) {
             throw new HandleExistException(request.handle());
         }
 
-        member.updateMember(request.profile(), request.handle());
-        imageService.saveTargetId(request.profile(), PROFILE, String.valueOf(member.getMemberId()));
+        member.updateMember(request.profile(), request.name(), request.handle());
+        imageService.updateImage(request.profile(), PROFILE, memberId);
     }
 
     /*

--- a/src/main/java/com/adregamdi/member/domain/Member.java
+++ b/src/main/java/com/adregamdi/member/domain/Member.java
@@ -1,22 +1,21 @@
 package com.adregamdi.member.domain;
 
 import com.adregamdi.core.entity.BaseTime;
-import com.adregamdi.core.oauth2.dto.SignUpDTO;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 @Entity
 @Table(name = "tbl_member")
 public class Member extends BaseTime {
     @Id
-    @GeneratedValue(generator = "UUID")
-    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "CHAR(36)")
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID memberId;
     @Column
     private String name; // 이름
@@ -49,21 +48,23 @@ public class Member extends BaseTime {
     @Enumerated(EnumType.STRING)
     private Role role; // 회원 권한
 
-    public Member(SignUpDTO signUpDTO) {
-        this.name = signUpDTO.getName();
-        this.profile = "https://adregamdi-dev2.s3.ap-northeast-2.amazonaws.com/profile/default_profile_image.png";
-        this.handle = signUpDTO.getHandle();
-        this.email = signUpDTO.getEmail();
-        this.age = signUpDTO.getAge();
-        this.gender = signUpDTO.getGender();
-        this.socialId = signUpDTO.getSocialId();
-        this.socialType = signUpDTO.getSocialType();
+    @Builder
+    public Member(String name, String profile, String handle, String email, String age, String gender, String socialId, SocialType socialType) {
+        this.name = name;
+        this.profile = profile;
+        this.handle = handle;
+        this.email = email;
+        this.age = age;
+        this.gender = gender;
+        this.socialId = socialId;
+        this.socialType = socialType;
         this.role = Role.MEMBER;
         this.refreshTokenStatus = false;
         this.memberStatus = true;
     }
 
-    public void updateMember(String profile, String handle) {
+    public void updateMember(String name, String profile, String handle) {
+        this.name = name;
         this.profile = profile;
         this.handle = handle;
     }

--- a/src/main/java/com/adregamdi/member/domain/Member.java
+++ b/src/main/java/com/adregamdi/member/domain/Member.java
@@ -15,7 +15,8 @@ import java.util.UUID;
 @Table(name = "tbl_member")
 public class Member extends BaseTime {
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
+    @GeneratedValue(generator = "UUID")
+    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "CHAR(36)")
     private UUID memberId;
     @Column
     private String name; // 이름

--- a/src/main/java/com/adregamdi/member/dto/request/UpdateMyMemberRequest.java
+++ b/src/main/java/com/adregamdi/member/dto/request/UpdateMyMemberRequest.java
@@ -6,10 +6,10 @@ import jakarta.validation.constraints.NotNull;
 public record UpdateMyMemberRequest(
         @NotNull
         @NotEmpty
-        String profile,
+        String name,
         @NotNull
         @NotEmpty
-        String name,
+        String profile,
         @NotNull
         @NotEmpty
         String handle

--- a/src/main/java/com/adregamdi/member/dto/request/UpdateMyMemberRequest.java
+++ b/src/main/java/com/adregamdi/member/dto/request/UpdateMyMemberRequest.java
@@ -9,6 +9,9 @@ public record UpdateMyMemberRequest(
         String profile,
         @NotNull
         @NotEmpty
+        String name,
+        @NotNull
+        @NotEmpty
         String handle
 ) {
 }

--- a/src/main/java/com/adregamdi/notification/domain/Notification.java
+++ b/src/main/java/com/adregamdi/notification/domain/Notification.java
@@ -5,8 +5,6 @@ import com.adregamdi.notification.dto.request.CreateNotificationRequest;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.UUID;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -17,8 +15,8 @@ public class Notification extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long notificationId;
-    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "CHAR(36)")
-    private UUID memberId; // 회원 id
+    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "VARCHAR(36)")
+    private String memberId;  // 회원 id
     @Column
     private String content; // 내용
     @Column
@@ -30,7 +28,7 @@ public class Notification extends BaseTime {
     private NotificationType type; // 알림 종류 (좋아요, 일정)
 
     public Notification(CreateNotificationRequest request) {
-        this.memberId = UUID.fromString(request.memberId());
+        this.memberId = request.memberId();
         this.content = request.content();
         this.uri = request.uri();
         this.isRead = false;

--- a/src/main/java/com/adregamdi/notification/domain/Notification.java
+++ b/src/main/java/com/adregamdi/notification/domain/Notification.java
@@ -17,7 +17,7 @@ public class Notification extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long notificationId;
-    @Column
+    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "CHAR(36)")
     private UUID memberId; // 회원 id
     @Column
     private String content; // 내용

--- a/src/main/java/com/adregamdi/notification/infrastructure/NotificationCustomRepositoryImpl.java
+++ b/src/main/java/com/adregamdi/notification/infrastructure/NotificationCustomRepositoryImpl.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import static com.adregamdi.notification.domain.QNotification.notification;
 
@@ -29,7 +28,7 @@ public class NotificationCustomRepositoryImpl implements NotificationCustomRepos
                 .select(notification)
                 .from(notification)
                 .where(
-                        notification.memberId.eq(UUID.fromString(memberId)),
+                        notification.memberId.eq(memberId),
                         notification.createdAt.gt(date),
                         toContainsLastId(lastId)
                 )

--- a/src/main/java/com/adregamdi/notification/infrastructure/NotificationRepository.java
+++ b/src/main/java/com/adregamdi/notification/infrastructure/NotificationRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationCustomRepository {
     @Modifying
@@ -17,5 +16,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             """)
     void deleteByCreatedAt(@Param("date") final LocalDateTime date);
 
-    void deleteByMemberId(UUID memberId);
+    void deleteByMemberId(String memberId);
 }

--- a/src/main/java/com/adregamdi/place/application/PlaceService.java
+++ b/src/main/java/com/adregamdi/place/application/PlaceService.java
@@ -24,7 +24,7 @@ public interface PlaceService {
     /*
      * [장소 리뷰 등록]
      * */
-    CreatePlaceReviewResponse createReview(final CreatePlaceReviewRequest request, final String memberId);
+    CreatePlaceReviewResponse createReview(final String memberId, final CreatePlaceReviewRequest request);
 
     /*
      * [장소 추가 카운트 증감]

--- a/src/main/java/com/adregamdi/place/application/PlaceServiceImpl.java
+++ b/src/main/java/com/adregamdi/place/application/PlaceServiceImpl.java
@@ -568,7 +568,10 @@ public class PlaceServiceImpl implements PlaceService {
     }
 
     private String formatToKoreanString(LocalDate date) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 M월 d일 방문", Locale.KOREAN);
-        return date.format(formatter);
+        if (date != null) {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 M월 d일 방문", Locale.KOREAN);
+            return date.format(formatter);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/adregamdi/place/application/PlaceServiceImpl.java
+++ b/src/main/java/com/adregamdi/place/application/PlaceServiceImpl.java
@@ -39,7 +39,10 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
@@ -158,7 +161,7 @@ public class PlaceServiceImpl implements PlaceService {
     @Override
     @Transactional
     public CreatePlaceReviewResponse createReview(final String memberId, final CreatePlaceReviewRequest request) {
-        placeReviewRepository.findByMemberIdAndPlaceId(UUID.fromString(memberId), request.placeId())
+        placeReviewRepository.findByMemberIdAndPlaceId(memberId, request.placeId())
                 .ifPresent(data -> {
                     throw new PlaceReviewExistException(data.getPlaceReviewId());
                 });
@@ -199,7 +202,7 @@ public class PlaceServiceImpl implements PlaceService {
     public GetPlaceResponse get(final String memberId, final Long placeId) {
         Place place = placeRepository.findById(placeId)
                 .orElseThrow(() -> new PlaceNotFoundException(placeId));
-        boolean isLiked = likesService.checkIsLiked(UUID.fromString(memberId), ContentType.PLACE, placeId);
+        boolean isLiked = likesService.checkIsLiked(memberId, ContentType.PLACE, placeId);
         return GetPlaceResponse.from(isLiked, place);
     }
 
@@ -305,7 +308,7 @@ public class PlaceServiceImpl implements PlaceService {
     @Override
     @Transactional(readOnly = true)
     public GetMyPlaceReviewResponse getMyReview(final String memberId) {
-        List<PlaceReview> placeReviews = placeReviewRepository.findAllByMemberIdOrderByPlaceReviewIdDesc(UUID.fromString(memberId))
+        List<PlaceReview> placeReviews = placeReviewRepository.findAllByMemberIdOrderByPlaceReviewIdDesc(memberId)
                 .orElseThrow(() -> new PlaceReviewNotFoundException(memberId));
         List<MyPlaceReviewDTO> myPlaceReviews = new ArrayList<>();
 

--- a/src/main/java/com/adregamdi/place/application/PlaceServiceImpl.java
+++ b/src/main/java/com/adregamdi/place/application/PlaceServiceImpl.java
@@ -184,7 +184,7 @@ public class PlaceServiceImpl implements PlaceService {
                 .map(PlaceReviewImage::getUrl)
                 .collect(Collectors.toList());
         if (!imageList.isEmpty()) {
-            imageService.updateImages(urls, PLACEREVIEW, String.valueOf(savePlaceReview.getPlaceReviewId()));
+            imageService.saveTargetId(urls, PLACEREVIEW, String.valueOf(savePlaceReview.getPlaceReviewId()));
         }
         return new CreatePlaceReviewResponse(savePlaceReview.getPlaceReviewId());
     }

--- a/src/main/java/com/adregamdi/place/domain/PlaceReview.java
+++ b/src/main/java/com/adregamdi/place/domain/PlaceReview.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,8 +17,8 @@ public class PlaceReview extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long placeReviewId;
-    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "CHAR(36)")
-    private UUID memberId; // 회원 id
+    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "VARCHAR(36)")
+    private String memberId;  // 회원 id
     @Column
     private Long placeId; // 장소 id
     @Column
@@ -29,7 +28,7 @@ public class PlaceReview extends BaseTime {
 
     @Builder
     public PlaceReview(String memberId, Long placeId, LocalDate visitDate, String content) {
-        this.memberId = UUID.fromString(memberId);
+        this.memberId = memberId;
         this.placeId = placeId;
         this.visitDate = visitDate;
         this.content = content;

--- a/src/main/java/com/adregamdi/place/domain/PlaceReview.java
+++ b/src/main/java/com/adregamdi/place/domain/PlaceReview.java
@@ -17,7 +17,7 @@ public class PlaceReview extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long placeReviewId;
-    @Column
+    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "CHAR(36)")
     private UUID memberId; // 회원 id
     @Column
     private Long placeId; // 장소 id

--- a/src/main/java/com/adregamdi/place/domain/PlaceReview.java
+++ b/src/main/java/com/adregamdi/place/domain/PlaceReview.java
@@ -2,15 +2,16 @@ package com.adregamdi.place.domain;
 
 import com.adregamdi.core.entity.BaseTime;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 @Entity
 @Table(name = "tbl_place_review")
 public class PlaceReview extends BaseTime {
@@ -26,6 +27,7 @@ public class PlaceReview extends BaseTime {
     @Column
     private String content; // 내용
 
+    @Builder
     public PlaceReview(String memberId, Long placeId, LocalDate visitDate, String content) {
         this.memberId = UUID.fromString(memberId);
         this.placeId = placeId;

--- a/src/main/java/com/adregamdi/place/dto/MyPlaceReviewDTO.java
+++ b/src/main/java/com/adregamdi/place/dto/MyPlaceReviewDTO.java
@@ -17,7 +17,10 @@ public record MyPlaceReviewDTO(
         String visitDate,
         String content,
         List<PlaceReviewImage> placeReviewImageList,
-        LocalDate createdAt
+        LocalDate createdAt,
+        String name,
+        String profile,
+        String handle
 ) {
     public static MyPlaceReviewDTO of(
             final Long placeReviewId,
@@ -29,7 +32,10 @@ public record MyPlaceReviewDTO(
             final String visitDate,
             final String content,
             final List<PlaceReviewImage> placeReviewImageList,
-            final LocalDate createdAt
+            final LocalDate createdAt,
+            final String name,
+            final String profile,
+            final String handle
     ) {
         return MyPlaceReviewDTO.builder()
                 .placeReviewId(placeReviewId)
@@ -42,6 +48,9 @@ public record MyPlaceReviewDTO(
                 .content(content)
                 .placeReviewImageList(placeReviewImageList)
                 .createdAt(createdAt)
+                .name(name)
+                .profile(profile)
+                .handle(handle)
                 .build();
     }
 }

--- a/src/main/java/com/adregamdi/place/dto/PlaceReviewDTO.java
+++ b/src/main/java/com/adregamdi/place/dto/PlaceReviewDTO.java
@@ -15,7 +15,10 @@ public record PlaceReviewDTO(
         String visitDate,
         String content,
         List<PlaceReviewImage> placeReviewImageList,
-        LocalDate createdAt
+        LocalDate createdAt,
+        String name,
+        String profile,
+        String handle
 ) {
     public static PlaceReviewDTO of(
             final Long placeReviewId,
@@ -25,7 +28,10 @@ public record PlaceReviewDTO(
             final String visitDate,
             final String content,
             final List<PlaceReviewImage> placeReviewImageList,
-            final LocalDate createdAt
+            final LocalDate createdAt,
+            final String name,
+            final String profile,
+            final String handle
     ) {
         return PlaceReviewDTO.builder()
                 .placeReviewId(placeReviewId)
@@ -36,6 +42,9 @@ public record PlaceReviewDTO(
                 .content(content)
                 .placeReviewImageList(placeReviewImageList)
                 .createdAt(createdAt)
+                .name(name)
+                .profile(profile)
+                .handle(handle)
                 .build();
     }
 }

--- a/src/main/java/com/adregamdi/place/dto/request/CreatePlaceReviewRequest.java
+++ b/src/main/java/com/adregamdi/place/dto/request/CreatePlaceReviewRequest.java
@@ -4,15 +4,12 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public record CreatePlaceReviewRequest(
         @NotNull
         @Positive
         Long placeId,
-        @NotNull
-        LocalDate visitDate,
         @NotNull
         @NotEmpty
         String content,

--- a/src/main/java/com/adregamdi/place/dto/response/GetPlaceReviewResponse.java
+++ b/src/main/java/com/adregamdi/place/dto/response/GetPlaceReviewResponse.java
@@ -15,7 +15,10 @@ public record GetPlaceReviewResponse(
         String visitDate,
         String content,
         List<PlaceReviewImage> placeReviewImageList,
-        LocalDate createdAt
+        LocalDate createdAt,
+        String name,
+        String profile,
+        String handle
 ) {
     public static GetPlaceReviewResponse of(
             final Long placeReviewId,
@@ -25,7 +28,10 @@ public record GetPlaceReviewResponse(
             final String visitDate,
             final String content,
             final List<PlaceReviewImage> placeReviewImages,
-            final LocalDate createdAt
+            final LocalDate createdAt,
+            final String name,
+            final String profile,
+            final String handle
     ) {
         return GetPlaceReviewResponse.builder()
                 .placeReviewId(placeReviewId)
@@ -36,6 +42,9 @@ public record GetPlaceReviewResponse(
                 .content(content)
                 .placeReviewImageList(placeReviewImages)
                 .createdAt(createdAt)
+                .name(name)
+                .profile(profile)
+                .handle(handle)
                 .build();
     }
 }

--- a/src/main/java/com/adregamdi/place/exception/PlaceException.java
+++ b/src/main/java/com/adregamdi/place/exception/PlaceException.java
@@ -35,6 +35,16 @@ public class PlaceException extends RuntimeException {
         }
     }
 
+    public static class PlaceReviewExistException extends PlaceException {
+        public PlaceReviewExistException() {
+            super("이미 해당 장소에 대한 리뷰가 존재합니다.");
+        }
+
+        public PlaceReviewExistException(final Object object) {
+            super(String.format("이미 해당 장소에 대한 리뷰가 존재합니다. - request info => %s", object));
+        }
+    }
+
     public static class PlaceReviewImageNotFoundException extends PlaceException {
         public PlaceReviewImageNotFoundException() {
             super("장소 리뷰 이미지가 존재하지 않습니다.");

--- a/src/main/java/com/adregamdi/place/infrastructure/PlaceReviewRepository.java
+++ b/src/main/java/com/adregamdi/place/infrastructure/PlaceReviewRepository.java
@@ -13,6 +13,8 @@ public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> 
 
     List<PlaceReview> findAllByPlaceIdOrderByPlaceReviewIdDesc(Long placeId);
 
+    Optional<PlaceReview> findByMemberIdAndPlaceId(UUID memberId, Long placeId);
+
     Optional<PlaceReview> findByMemberIdAndPlaceIdAndVisitDate(UUID memberId, Long placeId, LocalDate localDate);
 
     int countByPlaceId(Long placeId);

--- a/src/main/java/com/adregamdi/place/infrastructure/PlaceReviewRepository.java
+++ b/src/main/java/com/adregamdi/place/infrastructure/PlaceReviewRepository.java
@@ -6,16 +6,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> {
-    Optional<List<PlaceReview>> findAllByMemberIdOrderByPlaceReviewIdDesc(UUID memberId);
+    Optional<List<PlaceReview>> findAllByMemberIdOrderByPlaceReviewIdDesc(String memberId);
 
     List<PlaceReview> findAllByPlaceIdOrderByPlaceReviewIdDesc(Long placeId);
 
-    Optional<PlaceReview> findByMemberIdAndPlaceId(UUID memberId, Long placeId);
+    Optional<PlaceReview> findByMemberIdAndPlaceId(String memberId, Long placeId);
 
-    Optional<PlaceReview> findByMemberIdAndPlaceIdAndVisitDate(UUID memberId, Long placeId, LocalDate localDate);
+    Optional<PlaceReview> findByMemberIdAndPlaceIdAndVisitDate(String memberId, Long placeId, LocalDate localDate);
 
     int countByPlaceId(Long placeId);
 }

--- a/src/main/java/com/adregamdi/place/presentation/PlaceController.java
+++ b/src/main/java/com/adregamdi/place/presentation/PlaceController.java
@@ -54,13 +54,13 @@ public class PlaceController {
     @PostMapping("/review")
     @MemberAuthorize
     public ResponseEntity<ApiResponse<CreatePlaceReviewResponse>> createReview(
-            @RequestBody @Valid final CreatePlaceReviewRequest request,
-            @AuthenticationPrincipal final UserDetails userDetails
+            @AuthenticationPrincipal final UserDetails userDetails,
+            @RequestBody @Valid final CreatePlaceReviewRequest request
     ) {
         return ResponseEntity.ok()
                 .body(ApiResponse.<CreatePlaceReviewResponse>builder()
                         .statusCode(HttpStatus.CREATED.value())
-                        .data(placeService.createReview(request, userDetails.getUsername()))
+                        .data(placeService.createReview(userDetails.getUsername(), request))
                         .build()
                 );
     }

--- a/src/main/java/com/adregamdi/place/presentation/PlaceController.java
+++ b/src/main/java/com/adregamdi/place/presentation/PlaceController.java
@@ -159,7 +159,10 @@ public class PlaceController {
                                 placeReview.visitDate(),
                                 placeReview.content(),
                                 placeReview.placeReviewImageList(),
-                                placeReview.createdAt()
+                                placeReview.createdAt(),
+                                placeReview.name(),
+                                placeReview.profile(),
+                                placeReview.handle()
                         ))
                         .build()
                 );

--- a/src/main/java/com/adregamdi/search/application/SearchService.java
+++ b/src/main/java/com/adregamdi/search/application/SearchService.java
@@ -14,7 +14,10 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
 
 import static com.adregamdi.core.constant.Constant.LARGE_PAGE_SIZE;
 import static com.adregamdi.core.utils.PageUtil.generatePageAsc;
@@ -38,7 +41,7 @@ public class SearchService {
             totalCounts.put(SearchType.TRAVELOGUE, searchRepository.countTravelogues(keyword));
         }
         if (types.contains(SearchType.SHORTS)) {
-            shorts = searchRepository.searchShorts(keyword, generatePageAsc(page, pageSize, "title"), UUID.fromString(memberId));
+            shorts = searchRepository.searchShorts(keyword, generatePageAsc(page, pageSize, "title"), memberId);
             totalCounts.put(SearchType.SHORTS, searchRepository.countShorts(keyword));
         }
         if (types.contains(SearchType.PLACE)) {

--- a/src/main/java/com/adregamdi/search/infrastructure/SearchRepository.java
+++ b/src/main/java/com/adregamdi/search/infrastructure/SearchRepository.java
@@ -6,12 +6,10 @@ import com.adregamdi.search.dto.TravelogueSearchDTO;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-import java.util.UUID;
-
 public interface SearchRepository {
     Slice<TravelogueSearchDTO> searchTravelogues(String keyword, Pageable pageable);
 
-    Slice<ShortsSearchDTO> searchShorts(String keyword, Pageable pageable, UUID memberId);
+    Slice<ShortsSearchDTO> searchShorts(String keyword, Pageable pageable, String memberId);
 
     Slice<PlaceSearchDTO> searchPlaces(String keyword, Pageable pageable);
 

--- a/src/main/java/com/adregamdi/search/infrastructure/SearchRepositoryImpl.java
+++ b/src/main/java/com/adregamdi/search/infrastructure/SearchRepositoryImpl.java
@@ -47,7 +47,7 @@ public class SearchRepositoryImpl implements SearchRepository {
                         member.handle,
                         Expressions.constant(new ArrayList<String>())))
                 .from(travelogue)
-                .leftJoin(member).on(travelogue.memberId.eq(member.memberId))
+                .leftJoin(member).on(travelogue.memberId.eq(String.valueOf(member.memberId)))
                 .where(travelogue.title.startsWith(keyword))
                 .orderBy(makeOrderSpecifiers(travelogue, pageable))
                 .offset(pageable.getOffset())
@@ -96,7 +96,7 @@ public class SearchRepositoryImpl implements SearchRepository {
     }
 
     @Override
-    public Slice<ShortsSearchDTO> searchShorts(final String keyword, final Pageable pageable, final UUID memberId) {
+    public Slice<ShortsSearchDTO> searchShorts(final String keyword, final Pageable pageable, final String memberId) {
         List<ShortsSearchDTO> results = queryFactory
                 .select(Projections.constructor(ShortsSearchDTO.class,
                         shorts.shortsId,
@@ -131,7 +131,7 @@ public class SearchRepositoryImpl implements SearchRepository {
                                 "isLiked"
                         )))
                 .from(shorts)
-                .join(member).on(shorts.memberId.eq(member.memberId))
+                .join(member).on(shorts.memberId.eq(String.valueOf(member.memberId)))
                 .leftJoin(place).on(shorts.placeId.eq(place.placeId))
                 .leftJoin(travelogue).on(shorts.travelogueId.eq(travelogue.travelogueId))
                 .where(shorts.title.startsWith(keyword),

--- a/src/main/java/com/adregamdi/shorts/application/ShortsServiceImpl.java
+++ b/src/main/java/com/adregamdi/shorts/application/ShortsServiceImpl.java
@@ -19,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
 
 @Slf4j
 @Service
@@ -34,17 +33,17 @@ public class ShortsServiceImpl implements ShortsService {
 
     @Override
     public GetShortsResponse getShorts(String memberId, long lastId, int size) {
-        return shortsRepository.getShortsForMember(UUID.fromString(memberId), lastId, size);
+        return shortsRepository.getShortsForMember(memberId, lastId, size);
     }
 
     @Override
     public GetShortsResponse getUserShorts(String memberId, long lastShortsId, int size) {
-        return shortsRepository.getUserShorts(UUID.fromString(memberId), lastShortsId, size);
+        return shortsRepository.getUserShorts(memberId, lastShortsId, size);
     }
 
     @Override
     public GetShortsByPlaceIdResponse getShortsByPlaceId(String memberId, GetShortsByPlaceIdRequest request) {
-        return shortsRepository.getShortsByPlaceId(UUID.fromString(memberId), request);
+        return shortsRepository.getShortsByPlaceId(memberId, request);
     }
 
     @Override
@@ -60,7 +59,7 @@ public class ShortsServiceImpl implements ShortsService {
 
         Shorts savedShorts = shortsRepository.save(
                 Shorts.builder()
-                        .memberId(UUID.fromString(memberId))
+                        .memberId(memberId)
                         .shortsVideoUrl(videoUrls.getVideoUrl())
                         .thumbnailUrl(videoUrls.getVideoThumbnailUrl())
                         .build()

--- a/src/main/java/com/adregamdi/shorts/domain/Shorts.java
+++ b/src/main/java/com/adregamdi/shorts/domain/Shorts.java
@@ -26,7 +26,7 @@ public class Shorts extends BaseTime {
     @Comment(value = "쇼츠 제목")
     private String title;
 
-    @Column(name = "member_id")
+    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "CHAR(36)")
     @Comment(value = "작성자")
     private UUID memberId;
 

--- a/src/main/java/com/adregamdi/shorts/domain/Shorts.java
+++ b/src/main/java/com/adregamdi/shorts/domain/Shorts.java
@@ -10,8 +10,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
-import java.util.UUID;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -25,10 +23,10 @@ public class Shorts extends BaseTime {
     @Column(name = "title")
     @Comment(value = "쇼츠 제목")
     private String title;
-
-    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "CHAR(36)")
     @Comment(value = "작성자")
-    private UUID memberId;
+
+    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "VARCHAR(36)")
+    private String memberId;
 
     @Column(name = "place_id")
     @Comment(value = "장소 id")
@@ -55,7 +53,7 @@ public class Shorts extends BaseTime {
     private int viewCount;
 
     @Builder
-    public Shorts(Long shortsId, String title, UUID memberId, Long placeId, Long travelogueId, String shortsVideoUrl, String thumbnailUrl) {
+    public Shorts(Long shortsId, String title, String memberId, Long placeId, Long travelogueId, String shortsVideoUrl, String thumbnailUrl) {
         this.shortsId = shortsId;
         this.title = title;
         this.memberId = memberId;

--- a/src/main/java/com/adregamdi/shorts/dto/response/CreateShortsResponse.java
+++ b/src/main/java/com/adregamdi/shorts/dto/response/CreateShortsResponse.java
@@ -3,8 +3,6 @@ package com.adregamdi.shorts.dto.response;
 import com.adregamdi.shorts.domain.Shorts;
 import lombok.*;
 
-import java.util.UUID;
-
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -13,7 +11,7 @@ public class CreateShortsResponse {
 
     private Long shortsId;
     private String title;
-    private UUID memberId;
+    private String memberId;
     private Long placeId;
     private Long travelogueId;
 

--- a/src/main/java/com/adregamdi/shorts/infrastructure/ShortsCustomRepository.java
+++ b/src/main/java/com/adregamdi/shorts/infrastructure/ShortsCustomRepository.java
@@ -4,13 +4,11 @@ import com.adregamdi.shorts.dto.request.GetShortsByPlaceIdRequest;
 import com.adregamdi.shorts.dto.response.GetShortsByPlaceIdResponse;
 import com.adregamdi.shorts.dto.response.GetShortsResponse;
 
-import java.util.UUID;
-
 public interface ShortsCustomRepository {
 
-    GetShortsResponse getShortsForMember(UUID memberId, long lastId, int size);
+    GetShortsResponse getShortsForMember(String memberId, long lastId, int size);
 
-    GetShortsResponse getUserShorts(UUID memberId, long lastShortsId, int size);
+    GetShortsResponse getUserShorts(String memberId, long lastShortsId, int size);
 
-    GetShortsByPlaceIdResponse getShortsByPlaceId(UUID memberId, GetShortsByPlaceIdRequest request);
+    GetShortsByPlaceIdResponse getShortsByPlaceId(String memberId, GetShortsByPlaceIdRequest request);
 }

--- a/src/main/java/com/adregamdi/shorts/infrastructure/ShortsCustomRepositoryImpl.java
+++ b/src/main/java/com/adregamdi/shorts/infrastructure/ShortsCustomRepositoryImpl.java
@@ -16,13 +16,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.UUID;
 
-import static com.adregamdi.shorts.domain.QShorts.shorts;
-import static com.adregamdi.place.domain.QPlace.place;
-import static com.adregamdi.travelogue.domain.QTravelogue.travelogue;
 import static com.adregamdi.like.domain.QLike.like;
 import static com.adregamdi.member.domain.QMember.member;
+import static com.adregamdi.place.domain.QPlace.place;
+import static com.adregamdi.shorts.domain.QShorts.shorts;
+import static com.adregamdi.travelogue.domain.QTravelogue.travelogue;
 
 @Slf4j
 @Repository
@@ -32,7 +31,7 @@ public class ShortsCustomRepositoryImpl implements ShortsCustomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public GetShortsResponse getShortsForMember(UUID memberId, long lastId, int size) {
+    public GetShortsResponse getShortsForMember(String memberId, long lastId, int size) {
         BooleanExpression condition = shorts.shortsId.lt(lastId).and(shorts.assignedStatus.eq(true));
         OrderSpecifier<?> orderBy = shorts.shortsId.asc();
         return getShorts(memberId, condition, orderBy, size);
@@ -40,7 +39,7 @@ public class ShortsCustomRepositoryImpl implements ShortsCustomRepository {
 
 
     @Override
-    public GetShortsResponse getUserShorts(UUID memberId, long lastShortsId, int size) {
+    public GetShortsResponse getUserShorts(String memberId, long lastShortsId, int size) {
         BooleanExpression condition = shorts.shortsId.lt(lastShortsId)
                 .and(shorts.memberId.eq(memberId))
                 .and(shorts.assignedStatus.eq(true));
@@ -49,7 +48,7 @@ public class ShortsCustomRepositoryImpl implements ShortsCustomRepository {
     }
 
     @Override
-    public GetShortsByPlaceIdResponse getShortsByPlaceId(UUID memberId, GetShortsByPlaceIdRequest request) {
+    public GetShortsByPlaceIdResponse getShortsByPlaceId(String memberId, GetShortsByPlaceIdRequest request) {
         BooleanExpression condition = shorts.shortsId.lt(request.lastShortsId())
                 .and(shorts.placeId.eq(request.placeId()))
                 .and(shorts.assignedStatus.eq(true));
@@ -58,7 +57,7 @@ public class ShortsCustomRepositoryImpl implements ShortsCustomRepository {
         return new GetShortsByPlaceIdResponse(response.shortsList(), response.hasNext());
     }
 
-    private GetShortsResponse getShorts(UUID memberId, BooleanExpression condition, OrderSpecifier<?> orderBy, int size) {
+    private GetShortsResponse getShorts(String memberId, BooleanExpression condition, OrderSpecifier<?> orderBy, int size) {
 
         List<ShortsDTO> content = jpaQueryFactory
                 .select(Projections.constructor(ShortsDTO.class,
@@ -94,7 +93,7 @@ public class ShortsCustomRepositoryImpl implements ShortsCustomRepository {
                                 "isLiked"
                         )))
                 .from(shorts)
-                .join(member).on(shorts.memberId.eq(member.memberId))
+                .join(member).on(shorts.memberId.eq(String.valueOf(member.memberId)))
                 .leftJoin(place).on(shorts.placeId.eq(place.placeId))
                 .leftJoin(travelogue).on(shorts.travelogueId.eq(travelogue.travelogueId))
                 .where(condition)

--- a/src/main/java/com/adregamdi/shorts/infrastructure/ShortsRepository.java
+++ b/src/main/java/com/adregamdi/shorts/infrastructure/ShortsRepository.java
@@ -10,10 +10,9 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 public interface ShortsRepository extends JpaRepository<Shorts, Long>, ShortsCustomRepository {
-    Optional<Slice<Shorts>> findAllByMemberId(Pageable pageable, UUID memberId);
+    Optional<Slice<Shorts>> findAllByMemberId(Pageable pageable, String memberId);
 
     @Query("""
             SELECT s

--- a/src/main/java/com/adregamdi/travel/application/TravelService.java
+++ b/src/main/java/com/adregamdi/travel/application/TravelService.java
@@ -189,10 +189,10 @@ public class TravelService {
                 throw new TravelPlaceNotFoundException(travel.getTravelId());
             }
             for (TravelPlace travelPlace : travelPlaceList) {
-                PlaceReview placeReviewInfo = placeReviewRepository.findByMemberIdAndPlaceIdAndVisitDate(UUID.fromString(memberId), travelPlace.getPlaceId(), travelDay.getDate())
-                        .orElse(PlaceReview.builder().placeReviewId(0L).build());
+                PlaceReview placeReviewInfo = placeReviewRepository.findByMemberIdAndPlaceId(UUID.fromString(memberId), travelPlace.getPlaceId())
+                        .orElse(PlaceReview.builder().build());
                 PlaceReviewDTO placeReview = null;
-                if (placeReviewInfo.getPlaceReviewId() != 0) {
+                if (placeReviewInfo.getPlaceReviewId() != null && placeReviewInfo.getPlaceReviewId() != 0) {
                     placeReview = placeService.getReview(placeReviewInfo.getPlaceReviewId());
                 }
                 travelPlaceDTOS.add(TravelPlaceDTO.of(placeReview, travelPlace, placeService.get(memberId, travelPlace.getPlaceId()).place()));

--- a/src/main/java/com/adregamdi/travel/domain/Travel.java
+++ b/src/main/java/com/adregamdi/travel/domain/Travel.java
@@ -18,7 +18,7 @@ public class Travel extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long travelId;
-    @Column
+    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "CHAR(36)")
     private UUID memberId; // 회원 id
     @Column
     private LocalDate startDate; // 시작일

--- a/src/main/java/com/adregamdi/travel/domain/Travel.java
+++ b/src/main/java/com/adregamdi/travel/domain/Travel.java
@@ -1,25 +1,24 @@
 package com.adregamdi.travel.domain;
 
 import com.adregamdi.core.entity.BaseTime;
-import com.adregamdi.travel.dto.request.CreateMyTravelRequest;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 @Entity
 @Table(name = "tbl_travel")
 public class Travel extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long travelId;
-    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "CHAR(36)")
-    private UUID memberId; // 회원 id
+    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "VARCHAR(36)")
+    private String memberId;  // 회원 id
     @Column
     private LocalDate startDate; // 시작일
     @Column
@@ -27,17 +26,18 @@ public class Travel extends BaseTime {
     @Column
     private String title; // 제목
 
-    public Travel(CreateMyTravelRequest request, String memberId) {
-        this.memberId = UUID.fromString(memberId);
-        this.startDate = request.startDate();
-        this.endDate = request.endDate();
-        this.title = request.title();
+    @Builder
+    public Travel(String memberId, LocalDate startDate, LocalDate endDate, String title) {
+        this.memberId = memberId;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.title = title;
     }
 
-    public void update(CreateMyTravelRequest request, String memberId) {
-        this.memberId = UUID.fromString(memberId);
-        this.startDate = request.startDate();
-        this.endDate = request.endDate();
-        this.title = request.title();
+    public void update(String memberId, LocalDate startDate, LocalDate endDate, String title) {
+        this.memberId = memberId;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.title = title;
     }
 }

--- a/src/main/java/com/adregamdi/travel/infrastructure/TravelCustomRepositoryImpl.java
+++ b/src/main/java/com/adregamdi/travel/infrastructure/TravelCustomRepositoryImpl.java
@@ -10,7 +10,6 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.UUID;
 
 import static com.adregamdi.core.utils.RepositoryUtil.makeOrderSpecifiers;
 import static com.adregamdi.travel.domain.QTravel.travel;
@@ -29,7 +28,7 @@ public class TravelCustomRepositoryImpl implements TravelCustomRepository {
                         travel.endDate,
                         travel.title))
                 .from(travel)
-                .where(travel.memberId.eq(UUID.fromString(memberId)))
+                .where(travel.memberId.eq(memberId))
                 .orderBy(makeOrderSpecifiers(travel, pageable))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)

--- a/src/main/java/com/adregamdi/travel/infrastructure/TravelRepository.java
+++ b/src/main/java/com/adregamdi/travel/infrastructure/TravelRepository.java
@@ -4,8 +4,7 @@ import com.adregamdi.travel.domain.Travel;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
-import java.util.UUID;
 
 public interface TravelRepository extends JpaRepository<Travel, Long>, TravelCustomRepository {
-    Optional<Travel> findByTravelIdAndMemberId(Long travelId, UUID memberId);
+    Optional<Travel> findByTravelIdAndMemberId(Long travelId, String memberId);
 }

--- a/src/main/java/com/adregamdi/travelogue/application/TravelogueService.java
+++ b/src/main/java/com/adregamdi/travelogue/application/TravelogueService.java
@@ -166,7 +166,7 @@ public class TravelogueService {
                 .map(CreateMyTravelogueRequest.TravelogueImageInfo::url)
                 .toList();
 
-        imageService.updateImages(urls, TRAVELOGUE, String.valueOf(travelogueId));
+        imageService.saveTargetId(urls, TRAVELOGUE, String.valueOf(travelogueId));
     }
 
     private void saveTravelogueDaysAndReviews(

--- a/src/main/java/com/adregamdi/travelogue/application/TravelogueService.java
+++ b/src/main/java/com/adregamdi/travelogue/application/TravelogueService.java
@@ -236,7 +236,7 @@ public class TravelogueService {
 
             placeReviewsMap.put(travelogueDay.getTravelogueDayId(), placeReviewInfos);
         }
-        boolean isLiked = likesService.checkIsLiked(UUID.fromString(memberId), ContentType.TRAVELOGUE, travelogueId);
+        boolean isLiked = likesService.checkIsLiked(memberId, ContentType.TRAVELOGUE, travelogueId);
         return GetTravelogueResponse.of(isLiked, travelogue, travelogueImages, travelogueDays, placeReviewsMap);
     }
 

--- a/src/main/java/com/adregamdi/travelogue/application/TravelogueService.java
+++ b/src/main/java/com/adregamdi/travelogue/application/TravelogueService.java
@@ -126,13 +126,13 @@ public class TravelogueService {
                         travelogueImageRepository.saveAll(newTravelogueImages);
                     }
                 }
-                saveOrUpdateImages(request.travelogueId(), requestImages, false);
+                saveOrUpdateImages(request.travelogueId(), requestImages);
             } else {
                 for (CreateMyTravelogueRequest.TravelogueImageInfo travelogueImageUrl : requestImages) {
                     travelogueImages.add(new TravelogueImage(request.travelogueId(), travelogueImageUrl.url()));
                 }
                 travelogueImageRepository.saveAll(travelogueImages);
-                saveOrUpdateImages(request.travelogueId(), requestImages, true);
+                saveOrUpdateImages(request.travelogueId(), requestImages);
             }
         }
         return CreateMyTravelogueResponse.from(travelogue.getTravelogueId());
@@ -157,19 +157,16 @@ public class TravelogueService {
 
         travelogueImageRepository.saveAll(travelogueImages);
         if (requestImages != null) {
-            saveOrUpdateImages(travelogueId, requestImages, true);
+            saveOrUpdateImages(travelogueId, requestImages);
         }
     }
 
-    private void saveOrUpdateImages(Long travelogueId, List<CreateMyTravelogueRequest.TravelogueImageInfo> travelogueImages, boolean isSave) {
+    private void saveOrUpdateImages(Long travelogueId, List<CreateMyTravelogueRequest.TravelogueImageInfo> travelogueImages) {
         List<String> urls = travelogueImages.stream()
                 .map(CreateMyTravelogueRequest.TravelogueImageInfo::url)
                 .toList();
-        if (!travelogueImages.isEmpty() && isSave) {
-            imageService.saveTargetId(urls, TRAVELOGUE, String.valueOf(travelogueId));
-        } else if (!travelogueImages.isEmpty() || !isSave) {
-            imageService.updateImages(urls, TRAVELOGUE, String.valueOf(travelogueId));
-        }
+
+        imageService.updateImages(urls, TRAVELOGUE, String.valueOf(travelogueId));
     }
 
     private void saveTravelogueDaysAndReviews(

--- a/src/main/java/com/adregamdi/travelogue/domain/Travelogue.java
+++ b/src/main/java/com/adregamdi/travelogue/domain/Travelogue.java
@@ -16,7 +16,7 @@ public class Travelogue extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long travelogueId;
-    @Column
+    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "CHAR(36)")
     private UUID memberId; // 회원 id
     @Column
     private Long travelId; // 일정 id

--- a/src/main/java/com/adregamdi/travelogue/domain/Travelogue.java
+++ b/src/main/java/com/adregamdi/travelogue/domain/Travelogue.java
@@ -4,8 +4,6 @@ import com.adregamdi.core.entity.BaseTime;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.UUID;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -16,8 +14,8 @@ public class Travelogue extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long travelogueId;
-    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "CHAR(36)")
-    private UUID memberId; // 회원 id
+    @Column(name = "member_id", updatable = false, nullable = false, columnDefinition = "VARCHAR(36)")
+    private String memberId;  // 회원 id
     @Column
     private Long travelId; // 일정 id
     @Column
@@ -26,7 +24,7 @@ public class Travelogue extends BaseTime {
     private String introduction; // 소개
 
     public Travelogue(String memberId, Long travelId, String title, String introduction) {
-        this.memberId = UUID.fromString(memberId);
+        this.memberId = memberId;
         this.travelId = travelId;
         this.title = title;
         this.introduction = introduction;

--- a/src/main/java/com/adregamdi/travelogue/infrastructure/TravelogueCustomRepositoryImpl.java
+++ b/src/main/java/com/adregamdi/travelogue/infrastructure/TravelogueCustomRepositoryImpl.java
@@ -9,7 +9,10 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import static com.adregamdi.core.utils.RepositoryUtil.makeOrderSpecifiers;
 import static com.adregamdi.member.domain.QMember.member;
@@ -29,9 +32,9 @@ public class TravelogueCustomRepositoryImpl implements TravelogueCustomRepositor
                         member.handle,
                         travelogueImage.url)
                 .from(travelogue)
-                .join(member).on(travelogue.memberId.eq(member.memberId))
+                .join(member).on(travelogue.memberId.eq(String.valueOf(member.memberId)))
                 .leftJoin(travelogueImage).on(travelogue.travelogueId.eq(travelogueImage.travelogueId))
-                .where(travelogue.memberId.eq(UUID.fromString(memberId)))
+                .where(travelogue.memberId.eq(memberId))
                 .orderBy(makeOrderSpecifiers(travelogue, pageable))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
@@ -72,7 +75,7 @@ public class TravelogueCustomRepositoryImpl implements TravelogueCustomRepositor
                         member.handle,
                         travelogueImage.url)
                 .from(travelogue)
-                .join(member).on(travelogue.memberId.eq(member.memberId))
+                .join(member).on(travelogue.memberId.eq(String.valueOf(member.memberId)))
                 .leftJoin(travelogueImage).on(travelogue.travelogueId.eq(travelogueImage.travelogueId))
                 .orderBy(makeOrderSpecifiers(travelogue, pageable))
                 .offset(pageable.getOffset())


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #37 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- 애플 로그인 IOS, AOS에 대응되도록 구현
  - IOS: 애플 인가 코드로 클라이언트 생성-> 애플 서버로 요청 후 받은 id 토큰 파싱 -> 사용자 정보 추출 -> 서비스 가입/로그인
  - AOS: id 토큰 파싱-> 사용자 정보 추출-> 서비스 가입/로그인
  - 카카오/구글하고 요청 방식이 다르기 때문에 기존 로그인 API 요청 파라미터 수정

- DB에서 모든 테이블의 memberId가 BLOB으로 들어가는데 어느 시점인진 모르겠지만 자꾸 null로 바뀜
  - 컬럼 타입을 char(36)으로 변경해서 String으로 저장하도록 수정

- 이미지 저장/업뎃 방식 변경으로 인한 좋아요, 이미지 엔티티에 baseTime 상속 추가

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
