### PR TITLE
Refactoring - 리프레쉬 토큰 관리를 인메모리 캐싱 구조로 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // 레디스
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    
     // 애플 로그인을 위한 라이브러리
     implementation 'com.auth0:jwks-rsa:0.21.1'
     implementation 'org.json:json:20231013'
@@ -68,7 +72,6 @@ dependencies {
     // 동영상 압축을 위한 라이브러리
     implementation 'ws.schild:jave-core:3.5.0'
     implementation 'ws.schild:jave-all-deps:3.5.0'
-
 
     // 썸네일 제작을 위한 라이브러리
     implementation 'org.bytedeco:javacv-platform:1.5.9'

--- a/src/main/generated/com/adregamdi/member/domain/QMember.java
+++ b/src/main/generated/com/adregamdi/member/domain/QMember.java
@@ -44,10 +44,6 @@ public class QMember extends EntityPathBase<Member> {
 
     public final StringPath profile = createString("profile");
 
-    public final StringPath refreshToken = createString("refreshToken");
-
-    public final BooleanPath refreshTokenStatus = createBoolean("refreshTokenStatus");
-
     public final EnumPath<Role> role = createEnum("role", Role.class);
 
     public final StringPath socialAccessToken = createString("socialAccessToken");

--- a/src/main/java/com/adregamdi/core/config/RedisConfig.java
+++ b/src/main/java/com/adregamdi/core/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.adregamdi.core.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/adregamdi/core/config/SecurityConfig.java
+++ b/src/main/java/com/adregamdi/core/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.adregamdi.core.jwt.service.JwtService;
 import com.adregamdi.core.oauth2.application.CustomOAuth2UserService;
 import com.adregamdi.core.oauth2.handler.OAuth2LoginFailureHandler;
 import com.adregamdi.core.oauth2.handler.OAuth2LoginSuccessHandler;
+import com.adregamdi.core.redis.application.RedisService;
 import com.adregamdi.member.infrastructure.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -28,6 +29,7 @@ import java.util.Arrays;
 public class SecurityConfig {
     private final JwtService jwtService;
     private final MemberRepository memberRepository;
+    private final RedisService redisService;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
@@ -73,6 +75,6 @@ public class SecurityConfig {
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtService, memberRepository, Arrays.asList(ALLOWED_URIS));
+        return new JwtAuthenticationFilter(jwtService, redisService, memberRepository, Arrays.asList(ALLOWED_URIS));
     }
 }

--- a/src/main/java/com/adregamdi/core/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/adregamdi/core/handler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.adregamdi.core.handler;
 
 import com.adregamdi.block.exception.BlockException;
+import com.adregamdi.core.redis.exception.RedisException;
 import com.adregamdi.like.exception.LikesException;
 import com.adregamdi.media.exception.ImageException;
 import com.adregamdi.member.exception.MemberException;
@@ -142,6 +143,41 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.CONFLICT.value())
                 .body(new ErrorResponse(HttpStatus.CONFLICT.value(), exception.getMessage()));
+    }
+
+    // Redis 관련 예외 처리
+    @ExceptionHandler(RedisException.class)
+    public ResponseEntity<ErrorResponse> handleRedisException(RedisException exception) {
+        log.error("Redis 작업 중 오류 발생: {}", exception.getMessage());
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        String message = exception.getMessage();
+
+        if (exception instanceof RedisException.RedisConnectionFailureException) {
+            status = HttpStatus.SERVICE_UNAVAILABLE;
+            message = exception.getMessage();
+        } else if (exception instanceof RedisException.RedisQueryTimeoutException) {
+            status = HttpStatus.REQUEST_TIMEOUT;
+            message = exception.getMessage();
+        } else if (exception instanceof RedisException.RedisSystemException) {
+            message = exception.getMessage();
+        } else if (exception instanceof RedisException.RedisInvalidDataAccessException) {
+            status = HttpStatus.BAD_REQUEST;
+            message = exception.getMessage();
+        } else if (exception instanceof RedisException.RedisCommandExecutionException) {
+            message = exception.getMessage();
+        } else if (exception instanceof RedisException.RedisKeyNotFoundException) {
+            status = HttpStatus.NOT_FOUND;
+            message = exception.getMessage();
+        } else if (exception instanceof RedisException.RedisDataSerializationException) {
+            message = exception.getMessage();
+        } else if (exception instanceof RedisException.RedisOperationNotSupportedException) {
+            status = HttpStatus.BAD_REQUEST;
+            message = exception.getMessage();
+        }
+
+        return ResponseEntity
+                .status(status)
+                .body(new ErrorResponse(status.value(), message));
     }
 
     // 커스텀 예외

--- a/src/main/java/com/adregamdi/core/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/adregamdi/core/jwt/filter/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.adregamdi.core.jwt.filter;
 import com.adregamdi.core.exception.GlobalException;
 import com.adregamdi.core.handler.ErrorResponse;
 import com.adregamdi.core.jwt.service.JwtService;
+import com.adregamdi.core.redis.application.RedisService;
 import com.adregamdi.core.utils.PasswordUtil;
 import com.adregamdi.member.domain.Member;
 import com.adregamdi.member.infrastructure.MemberRepository;
@@ -33,6 +34,7 @@ import java.util.Objects;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
     private final JwtService jwtService;
+    private final RedisService redisService;
     private final MemberRepository memberRepository;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
     private final List<String> allowedUris;
@@ -89,16 +91,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             final String refreshToken
     ) {
         try {
-            memberRepository.findByRefreshToken(refreshToken)
-                    .ifPresentOrElse(member -> {
-                        jwtService.validateRefreshToken(refreshToken, member);
-                        String newAccessToken = jwtService.createAccessToken(member.getMemberId(), member.getRole());
-                        String newRefreshToken = reIssueRefreshToken(member);
-                        jwtService.sendAccessAndRefreshToken(response, newAccessToken, newRefreshToken);
-                    }, () -> {
-                        throw new GlobalException.TokenValidationException("해당 리프레시 토큰을 가진 회원이 없습니다.");
-                    });
-        } catch (GlobalException.RefreshTokenMismatchException | GlobalException.TokenValidationException e) {
+            String memberId = redisService.getMemberIdByRefreshToken(refreshToken);
+            if (memberId == null) {
+                throw new GlobalException.TokenValidationException("유효하지 않은 리프레시 토큰입니다.");
+            }
+
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new GlobalException.TokenValidationException("해당 리프레시 토큰을 가진 회원이 없습니다."));
+
+            jwtService.validateRefreshToken(refreshToken);
+            String newAccessToken = jwtService.createAccessToken(member.getMemberId(), member.getRole());
+            String newRefreshToken = reIssueRefreshToken(member.getMemberId());
+            jwtService.sendAccessAndRefreshToken(response, newAccessToken, newRefreshToken);
+
+        } catch (GlobalException.TokenValidationException e) {
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setCharacterEncoding("UTF-8");
@@ -110,10 +116,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
     }
 
-    private String reIssueRefreshToken(final Member member) {
+    private String reIssueRefreshToken(final String memberId) {
         String reIssuedRefreshToken = jwtService.createRefreshToken();
-        member.updateRefreshToken(reIssuedRefreshToken);
-        memberRepository.saveAndFlush(member);
+        redisService.saveRefreshToken(memberId, reIssuedRefreshToken);
         return reIssuedRefreshToken;
     }
 

--- a/src/main/java/com/adregamdi/core/jwt/service/JwtService.java
+++ b/src/main/java/com/adregamdi/core/jwt/service/JwtService.java
@@ -202,7 +202,12 @@ public class JwtService {
         }
     }
 
-    public void validateRefreshToken(final String refreshToken) {
+    public void validateRefreshToken(final String memberId, final String refreshToken) {
+        if (!refreshToken.equals(redisService.getRefreshToken(memberId))) {
+            log.info("저장된 리프레시 토큰과 제공된 리프레시 토큰이 일치하지 않습니다. MemberId: {}", memberId);
+            throw new GlobalException.RefreshTokenMismatchException();
+        }
+
         try {
             DecodedJWT jwt = JWT.decode(refreshToken);
 

--- a/src/main/java/com/adregamdi/core/oauth2/application/CustomOAuth2UserService.java
+++ b/src/main/java/com/adregamdi/core/oauth2/application/CustomOAuth2UserService.java
@@ -34,6 +34,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     @Transactional
     public OAuth2User loadUser(final OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         log.info("CustomOAuth2UserService.loadUser() 실행 - OAuth2 로그인 요청 진입");
+        log.info("{} socialAccessToken", userRequest.getAccessToken().getTokenValue());
 
         OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
         OAuth2User oAuth2User = delegate.loadUser(userRequest);

--- a/src/main/java/com/adregamdi/core/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/adregamdi/core/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -42,8 +42,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         String accessToken = jwtService.createAccessToken(findMember.getMemberId(), findMember.getRole());
         String refreshToken = jwtService.createRefreshToken();
 
-        findMember.updateRefreshToken(refreshToken);
-        findMember.updateRefreshTokenStatus(true);
+//        findMember.updateRefreshToken(refreshToken);
+//        findMember.updateRefreshTokenStatus(true);
         String targetUrl = createURI(accessToken, refreshToken).toString();
 
         response.sendRedirect(targetUrl);

--- a/src/main/java/com/adregamdi/core/redis/application/RedisService.java
+++ b/src/main/java/com/adregamdi/core/redis/application/RedisService.java
@@ -1,10 +1,16 @@
 package com.adregamdi.core.redis.application;
 
+import com.adregamdi.core.redis.exception.RedisException;
+import jakarta.persistence.QueryTimeoutException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.serializer.SerializationException;
 import org.springframework.stereotype.Service;
 
 import java.util.concurrent.TimeUnit;
@@ -21,12 +27,38 @@ public class RedisService {
     private final long REFRESH_TOKEN_EXPIRE_TIME = 60 * 60 * 24 * 14; // 14일
 
     public void saveRefreshToken(final String memberId, final String refreshToken) {
-        redisTemplate.opsForValue()
-                .set("RT:" + memberId, refreshToken, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.SECONDS);
+        try {
+            redisTemplate.opsForValue()
+                    .set(REFRESH_TOKEN_PREFIX + memberId, refreshToken, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.SECONDS);
+        } catch (RedisConnectionFailureException e) {
+            log.error("리프레시 토큰 저장 중 Redis 연결 실패", e);
+            throw new RedisException.RedisConnectionFailureException();
+        } catch (RedisException e) {
+            log.error("리프레시 토큰 저장 중 Redis 오류", e);
+            throw new RedisException.RedisSystemException();
+        } catch (Exception e) {
+            log.error("리프레시 토큰 저장 중 예기치 않은 오류", e);
+            throw new RedisException.RedisCommandExecutionException();
+        }
     }
 
     public String getRefreshToken(final String memberId) {
-        return redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + memberId);
+        try {
+            String token = redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + memberId);
+            if (token == null) {
+                throw new RedisException.RedisKeyNotFoundException();
+            }
+            return token;
+        } catch (RedisConnectionFailureException e) {
+            log.error("리프레시 토큰 조회 중 Redis 연결 실패", e);
+            throw new RedisException.RedisConnectionFailureException();
+        } catch (SerializationException e) {
+            log.error("리프레시 토큰 역직렬화 중 오류", e);
+            throw new RedisException.RedisDataSerializationException();
+        } catch (RedisException e) {
+            log.error("리프레시 토큰 조회 중 Redis 오류", e);
+            throw new RedisException.RedisSystemException();
+        }
     }
 
     public String getMemberIdByRefreshToken(String refreshToken) {
@@ -45,29 +77,80 @@ public class RedisService {
                     break;
                 }
             }
+        } catch (RedisConnectionFailureException e) {
+            log.error("RefreshToken으로 MemberId 조회 중 Redis 연결 실패", e);
+            throw new RedisException.RedisConnectionFailureException();
+        } catch (QueryTimeoutException e) {
+            log.error("RefreshToken으로 MemberId 조회 중 Redis 쿼리 시간 초과", e);
+            throw new RedisException.RedisQueryTimeoutException();
+        } catch (RedisSystemException e) {
+            log.error("RefreshToken으로 MemberId 조회 중 Redis 시스템 오류", e);
+            throw new RedisException.RedisSystemException();
+        } catch (InvalidDataAccessApiUsageException e) {
+            log.error("RefreshToken으로 MemberId 조회 중 잘못된 Redis API 사용", e);
+            throw new RedisException.RedisInvalidDataAccessException();
+        } catch (UnsupportedOperationException e) {
+            log.error("RefreshToken으로 MemberId 조회 중 지원되지 않는 작업", e);
+            throw new RedisException.RedisOperationNotSupportedException();
         } catch (Exception e) {
-            log.error("Error while scanning Redis keys", e);
+            log.error("RefreshToken으로 MemberId 조회 중 예기치 않은 오류 발생", e);
+            throw new RedisException.RedisCommandExecutionException();
         }
         return result;
     }
 
     public void deleteRefreshToken(final String memberId) {
-        redisTemplate.delete(REFRESH_TOKEN_PREFIX + memberId);
+        try {
+            Boolean deleted = redisTemplate.delete(REFRESH_TOKEN_PREFIX + memberId);
+            if (Boolean.FALSE.equals(deleted)) {
+                throw new RedisException.RedisKeyNotFoundException();
+            }
+        } catch (RedisConnectionFailureException e) {
+            log.error("리프레시 토큰 삭제 중 Redis 연결 실패", e);
+            throw new RedisException.RedisConnectionFailureException();
+        } catch (RedisException e) {
+            log.error("리프레시 토큰 삭제 중 Redis 오류", e);
+            throw new RedisException.RedisSystemException();
+        } catch (Exception e) {
+            log.error("리프레시 토큰 삭제 중 예기치 않은 오류", e);
+            throw new RedisException.RedisCommandExecutionException();
+        }
     }
 
     public void logoutUser(final String memberId, final String accessToken) {
-        String refreshTokenKey = REFRESH_TOKEN_PREFIX + memberId;
-        String logoutAccessTokenKey = LOGOUT_ACCESS_TOKEN_PREFIX + accessToken;
+        try {
+            String logoutAccessTokenKey = LOGOUT_ACCESS_TOKEN_PREFIX + accessToken;
 
-        // 리프레시 토큰 삭제
-        redisTemplate.delete(refreshTokenKey);
+            // 리프레시 토큰 삭제
+            deleteRefreshToken(memberId);
 
-        // 로그아웃된 액세스 토큰 등록
-        redisTemplate.opsForValue().set(logoutAccessTokenKey, "true", ACCESS_TOKEN_EXPIRE_TIME, TimeUnit.SECONDS);
+            // 로그아웃된 액세스 토큰 등록
+            redisTemplate.opsForValue().set(logoutAccessTokenKey, "true", ACCESS_TOKEN_EXPIRE_TIME, TimeUnit.SECONDS);
+        } catch (RedisConnectionFailureException e) {
+            log.error("로그아웃 처리 중 Redis 연결 실패", e);
+            throw new RedisException.RedisConnectionFailureException();
+        } catch (RedisException e) {
+            log.error("로그아웃 처리 중 Redis 오류", e);
+            throw new RedisException.RedisSystemException();
+        } catch (Exception e) {
+            log.error("로그아웃 처리 중 예기치 않은 오류", e);
+            throw new RedisException.RedisCommandExecutionException();
+        }
     }
 
     public boolean isLoggedOutAccessToken(final String accessToken) {
-        String logoutAccessTokenKey = LOGOUT_ACCESS_TOKEN_PREFIX + accessToken;
-        return Boolean.TRUE.equals(redisTemplate.hasKey(logoutAccessTokenKey));
+        try {
+            String logoutAccessTokenKey = LOGOUT_ACCESS_TOKEN_PREFIX + accessToken;
+            return Boolean.TRUE.equals(redisTemplate.hasKey(logoutAccessTokenKey));
+        } catch (RedisConnectionFailureException e) {
+            log.error("로그아웃된 액세스 토큰 확인 중 Redis 연결 실패", e);
+            throw new RedisException.RedisConnectionFailureException();
+        } catch (RedisException e) {
+            log.error("로그아웃된 액세스 토큰 확인 중 Redis 오류", e);
+            throw new RedisException.RedisSystemException();
+        } catch (Exception e) {
+            log.error("로그아웃된 액세스 토큰 확인 중 예기치 않은 오류", e);
+            throw new RedisException.RedisCommandExecutionException();
+        }
     }
 }

--- a/src/main/java/com/adregamdi/core/redis/application/RedisService.java
+++ b/src/main/java/com/adregamdi/core/redis/application/RedisService.java
@@ -1,0 +1,47 @@
+package com.adregamdi.core.redis.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private static final String REFRESH_TOKEN_PREFIX = "RT:";
+    private static final String LOGOUT_ACCESS_TOKEN_PREFIX = "LOGOUT:AT:";
+    private final RedisTemplate<String, String> redisTemplate;
+    private final long ACCESS_TOKEN_EXPIRE_TIME = 60 * 30; // 30분
+    private final long REFRESH_TOKEN_EXPIRE_TIME = 60 * 60 * 24 * 14; // 14일
+
+    public void saveRefreshToken(final String memberId, final String refreshToken) {
+        redisTemplate.opsForValue()
+                .set("RT:" + memberId, refreshToken, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.SECONDS);
+    }
+
+    public String getRefreshToken(final String memberId) {
+        return redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + memberId);
+    }
+
+    public void deleteRefreshToken(final String memberId) {
+        redisTemplate.delete(REFRESH_TOKEN_PREFIX + memberId);
+    }
+
+    public void logoutUser(final String memberId, final String accessToken) {
+        String refreshTokenKey = REFRESH_TOKEN_PREFIX + memberId;
+        String logoutAccessTokenKey = LOGOUT_ACCESS_TOKEN_PREFIX + accessToken;
+
+        // 리프레시 토큰 삭제
+        redisTemplate.delete(refreshTokenKey);
+
+        // 로그아웃된 액세스 토큰 등록
+        redisTemplate.opsForValue().set(logoutAccessTokenKey, "true", ACCESS_TOKEN_EXPIRE_TIME, TimeUnit.SECONDS);
+    }
+
+    public boolean isLoggedOutAccessToken(final String accessToken) {
+        String logoutAccessTokenKey = LOGOUT_ACCESS_TOKEN_PREFIX + accessToken;
+        return Boolean.TRUE.equals(redisTemplate.hasKey(logoutAccessTokenKey));
+    }
+}

--- a/src/main/java/com/adregamdi/core/redis/exception/RedisException.java
+++ b/src/main/java/com/adregamdi/core/redis/exception/RedisException.java
@@ -1,0 +1,56 @@
+package com.adregamdi.core.redis.exception;
+
+public class RedisException extends RuntimeException {
+    public RedisException(final String message) {
+        super(message);
+    }
+
+    public static class RedisConnectionFailureException extends RedisException {
+
+        public RedisConnectionFailureException() {
+            super("Redis 연결에 실패했습니다.");
+        }
+    }
+
+    public static class RedisQueryTimeoutException extends RedisException {
+        public RedisQueryTimeoutException() {
+            super("Redis 쿼리 실행 시간이 초과되었습니다.");
+        }
+    }
+
+    public static class RedisSystemException extends RedisException {
+        public RedisSystemException() {
+            super("Redis 시스템 오류가 발생했습니다.");
+        }
+    }
+
+    public static class RedisInvalidDataAccessException extends RedisException {
+        public RedisInvalidDataAccessException() {
+            super("잘못된 Redis 데이터 접근 방식이 사용되었습니다.");
+        }
+    }
+
+    public static class RedisCommandExecutionException extends RedisException {
+        public RedisCommandExecutionException() {
+            super("Redis 명령 실행 중 오류가 발생했습니다.");
+        }
+    }
+
+    public static class RedisKeyNotFoundException extends RedisException {
+        public RedisKeyNotFoundException() {
+            super("요청한 Redis 키를 찾을 수 없습니다.");
+        }
+    }
+
+    public static class RedisDataSerializationException extends RedisException {
+        public RedisDataSerializationException() {
+            super("Redis 데이터 직렬화 또는 역직렬화 중 오류가 발생했습니다.");
+        }
+    }
+
+    public static class RedisOperationNotSupportedException extends RedisException {
+        public RedisOperationNotSupportedException() {
+            super("지원되지 않는 Redis 작업입니다.");
+        }
+    }
+}

--- a/src/main/java/com/adregamdi/member/application/MemberService.java
+++ b/src/main/java/com/adregamdi/member/application/MemberService.java
@@ -1,5 +1,6 @@
 package com.adregamdi.member.application;
 
+import com.adregamdi.core.redis.application.RedisService;
 import com.adregamdi.media.application.ImageService;
 import com.adregamdi.member.domain.Member;
 import com.adregamdi.member.domain.Role;
@@ -31,6 +32,7 @@ import static com.adregamdi.media.domain.ImageTarget.PROFILE;
 public class MemberService {
     private final WebClient webClient;
     private final ImageService imageService;
+    private final RedisService redisService;
     private final MemberRepository memberRepository;
 
     /*
@@ -73,11 +75,14 @@ public class MemberService {
      * [로그아웃]
      */
     @Transactional
-    public void logout(final String memberId) {
-        Member member = memberRepository.findByMemberIdAndMemberStatus(memberId, true)
-                .orElseThrow(() -> new MemberNotFoundException(memberId));
+    public void logout(final String memberId, final String accessToken) {
+//        Member member = memberRepository.findByMemberIdAndMemberStatus(memberId, true)
+//                .orElseThrow(() -> new MemberNotFoundException(memberId));
+//
+//        member.updateRefreshTokenStatus(false);
 
-        member.updateRefreshTokenStatus(false);
+        // Redis에서 리프레시 토큰 삭제 및 액세스 토큰 로그아웃 처리
+        redisService.logoutUser(memberId, accessToken);
     }
 
     /*
@@ -90,7 +95,6 @@ public class MemberService {
 
         member.updateAuthorization(Role.GUEST);
         member.updateMemberStatus(false);
-        member.updateRefreshTokenStatus(false);
     }
 
     /*
@@ -116,7 +120,7 @@ public class MemberService {
     }
 
     private void deleteData(final String memberId) {
-
+        
     }
 
     /*

--- a/src/main/java/com/adregamdi/member/domain/Member.java
+++ b/src/main/java/com/adregamdi/member/domain/Member.java
@@ -37,10 +37,6 @@ public class Member extends BaseTime {
     @Column
     private String socialAccessToken; // 소셜 액세스 토큰
     @Column
-    private String refreshToken; // 리프레쉬 토큰
-    @Column
-    private Boolean refreshTokenStatus; // 리프레쉬 토큰 상태 (T: 로그인/F: 로그아웃)
-    @Column
     private LocalDateTime connectedAt; // 마지막 접속 시간
     @Column
     private Boolean memberStatus; // 회원 상태 (T: 등록/F: 탈퇴)
@@ -63,7 +59,6 @@ public class Member extends BaseTime {
         this.socialId = socialId;
         this.socialType = socialType;
         this.role = Role.MEMBER;
-        this.refreshTokenStatus = false;
         this.memberStatus = true;
     }
 
@@ -75,14 +70,6 @@ public class Member extends BaseTime {
 
     public void updateSocialAccessToken(String socialAccessToken) {
         this.socialAccessToken = socialAccessToken;
-    }
-
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
-
-    public void updateRefreshTokenStatus(Boolean status) {
-        this.refreshTokenStatus = status;
     }
 
     public void updateAuthorization(Role role) {

--- a/src/main/java/com/adregamdi/member/infrastructure/MemberRepository.java
+++ b/src/main/java/com/adregamdi/member/infrastructure/MemberRepository.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, String> {
+public interface MemberRepository extends JpaRepository<Member, String>, MemberCustomRepository {
     Optional<Member> findByMemberIdAndMemberStatus(String memberId, boolean memberStatus);
 
     Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String id);

--- a/src/main/java/com/adregamdi/member/infrastructure/MemberRepository.java
+++ b/src/main/java/com/adregamdi/member/infrastructure/MemberRepository.java
@@ -12,8 +12,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
-    Optional<Member> findByRefreshToken(String refreshToken);
-
     Optional<Member> findByMemberIdAndMemberStatus(String memberId, boolean memberStatus);
 
     Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String id);


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #209 
## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
인메모리 방식으로 토큰을 관리하기 위해 Redis 도입

redis 사용 이유
- 데이터 영속성 유지가 가능하기 때문에 자바 자료구조의 한계를 넘음
- 고성능 및 낮은 지연 시간
- 분산 환경에서 쉽게 확장 가능
- 사프니까

리프레쉬 토큰 관리 방식
- 기존: DB 회원 테이블에서 리프레쉬 토큰 저장
- 변경: 레디스에 저장

변경 후 기대 효과: 디스크를 찍고 오지 않고 메모리에서 데이터 관리가 가능하기 때문에 
DB 부하가 감소하고 기존보다 빠를 것이다.

로그아웃 회원 관리 방식
- 기존: DB 회원 테이블에서 리프레쉬 토큰 상태 저장하고 이 상태 컬럼으로 판단했음
- 변경: 레디스에 로그아웃 된 액세스 토큰을 저장하고 이걸로 판단

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
- 레디스에 리프레쉬 토큰이 저장되는 모습
![image](https://github.com/user-attachments/assets/8e0a768e-2b05-47ef-a69c-1c5dafe38e23)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
레디스는... 윈도우에서 못 깔고 리눅스나 macOS에서 가능하다 ㅠ