### PR TITLE
Feature - 특정 쇼츠 조회 API 구현

### DIFF
--- a/src/main/java/com/adregamdi/like/application/LikesService.java
+++ b/src/main/java/com/adregamdi/like/application/LikesService.java
@@ -45,7 +45,6 @@ public class LikesService {
 
     @Transactional
     public CreateLikesResponse create(String memberId, CreateLikesRequest request) {
-
         boolean isLiked = likesRepository.findByMemberIdAndContentTypeAndContentId(memberId, request.getContentType(), request.contentId()).isPresent();
         if (isLiked) {
             return new CreateLikesResponse(true);
@@ -84,13 +83,11 @@ public class LikesService {
                     contentType,
                     NotificationType.LIKES));
         }
-
         return new CreateLikesResponse(likesRepository.save(like).equals(like));
     }
 
     @Transactional
     public CreateShortsLikeResponse createShortsLike(String memberId, Long shortsId) {
-
         Like like = Like.builder()
                 .memberId(memberId)
                 .contentType(ContentType.SHORTS)
@@ -114,10 +111,7 @@ public class LikesService {
                 member.getHandle(),
                 contentType,
                 NotificationType.LIKES));
-
-        return new CreateShortsLikeResponse(
-                likesRepository.countByContentTypeAndContentId(ContentType.SHORTS, shortsId)
-        );
+        return new CreateShortsLikeResponse(likesRepository.countByContentTypeAndContentId(ContentType.SHORTS, shortsId));
     }
 
 
@@ -147,9 +141,13 @@ public class LikesService {
 
     }
 
+    @Transactional
+    public Integer getLikesCount(final ContentType contentType, final Long contentId) {
+        return likesRepository.countByContentTypeAndContentId(contentType, contentId);
+    }
+
     @Transactional(readOnly = true)
     public Boolean checkIsLiked(String memberId, ContentType contentType, Long contentId) {
-
         return likesRepository.checkIsLiked(memberId, contentType, contentId);
     }
 
@@ -158,7 +156,6 @@ public class LikesService {
         if (likes.isEmpty()) {
             return;
         }
-
         likesRepository.deleteAll(likes);
     }
 }

--- a/src/main/java/com/adregamdi/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/adregamdi/member/application/MemberServiceImpl.java
@@ -59,7 +59,7 @@ public class MemberServiceImpl implements MemberService {
      * [내 정보 조회]
      */
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public GetMyMemberResponse getMyMember(final String memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));

--- a/src/main/java/com/adregamdi/member/dto/ShortsWithMemberDTO.java
+++ b/src/main/java/com/adregamdi/member/dto/ShortsWithMemberDTO.java
@@ -1,0 +1,17 @@
+package com.adregamdi.member.dto;
+
+public record ShortsWithMemberDTO(
+        Long shortsId,
+        String title,
+        String memberId,
+        Long placeId,
+        Long travelogueId,
+        String shortsVideoUrl,
+        String thumbnailUrl,
+        boolean assignedStatus,
+        int viewCount,
+        String memberName,
+        String memberHandle,
+        String memberProfile
+) {
+}

--- a/src/main/java/com/adregamdi/place/application/PlaceServiceImpl.java
+++ b/src/main/java/com/adregamdi/place/application/PlaceServiceImpl.java
@@ -233,7 +233,7 @@ public class PlaceServiceImpl implements PlaceService {
         Place place = placeRepository.findById(placeId)
                 .orElseThrow(() -> new PlaceNotFoundException(placeId));
         boolean isLiked = likesService.checkIsLiked(memberId, ContentType.PLACE, placeId);
-        return GetPlaceResponse.from(isLiked, place);
+        return GetPlaceResponse.of(isLiked, place);
     }
 
     /*

--- a/src/main/java/com/adregamdi/place/dto/response/GetPlaceResponse.java
+++ b/src/main/java/com/adregamdi/place/dto/response/GetPlaceResponse.java
@@ -8,7 +8,7 @@ public record GetPlaceResponse(
         boolean isLiked,
         Place place
 ) {
-    public static GetPlaceResponse from(final boolean isLiked, final Place place) {
+    public static GetPlaceResponse of(final boolean isLiked, final Place place) {
         return GetPlaceResponse.builder()
                 .isLiked(isLiked)
                 .place(place)

--- a/src/main/java/com/adregamdi/shorts/application/ShortsService.java
+++ b/src/main/java/com/adregamdi/shorts/application/ShortsService.java
@@ -3,12 +3,11 @@ package com.adregamdi.shorts.application;
 import com.adregamdi.shorts.dto.request.CreateShortsRequest;
 import com.adregamdi.shorts.dto.request.GetShortsByPlaceIdRequest;
 import com.adregamdi.shorts.dto.request.UpdateShortsRequest;
-import com.adregamdi.shorts.dto.response.GetShortsByPlaceIdResponse;
-import com.adregamdi.shorts.dto.response.GetShortsResponse;
-import com.adregamdi.shorts.dto.response.SaveVideoResponse;
-import com.adregamdi.shorts.dto.response.UploadVideoDTO;
+import com.adregamdi.shorts.dto.response.*;
 
 public interface ShortsService {
+    GetShortsByShortsIdResponse getShortsByShortsId(final String currentMemberId, final Long shortsId);
+
     GetShortsResponse getShorts(String memberId, long lastShortsId, int size);
 
     GetShortsResponse getUserShorts(String memberIdForTest, long lastShortsId, int size);

--- a/src/main/java/com/adregamdi/shorts/dto/ShortsDTO.java
+++ b/src/main/java/com/adregamdi/shorts/dto/ShortsDTO.java
@@ -1,5 +1,6 @@
 package com.adregamdi.shorts.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -27,6 +28,7 @@ public class ShortsDTO {
     private int likeCount;
     private Boolean isLiked;
 
+    @Builder
     public ShortsDTO(Long shortsId, String title, String memberId, String name, String handle, String profile, Long placeId, String placeTitle, String placeImage, Long travelogueId, String travelogueTitle, String travelogueImage, String shortsVideoUrl, String thumbnailUrl, Integer viewCount, Integer likeCount, Boolean isLiked) {
         this.shortsId = shortsId;
         this.title = title;
@@ -46,5 +48,5 @@ public class ShortsDTO {
         this.likeCount = likeCount == null ? 0 : likeCount;
         this.isLiked = isLiked;
     }
-    
+
 }

--- a/src/main/java/com/adregamdi/shorts/dto/response/GetShortsByShortsIdResponse.java
+++ b/src/main/java/com/adregamdi/shorts/dto/response/GetShortsByShortsIdResponse.java
@@ -1,0 +1,15 @@
+package com.adregamdi.shorts.dto.response;
+
+import com.adregamdi.shorts.dto.ShortsDTO;
+import lombok.Builder;
+
+@Builder
+public record GetShortsByShortsIdResponse(
+        ShortsDTO shorts
+) {
+    public static GetShortsByShortsIdResponse from(final ShortsDTO shorts) {
+        return GetShortsByShortsIdResponse.builder()
+                .shorts(shorts)
+                .build();
+    }
+}

--- a/src/main/java/com/adregamdi/shorts/infrastructure/ShortsRepository.java
+++ b/src/main/java/com/adregamdi/shorts/infrastructure/ShortsRepository.java
@@ -14,7 +14,15 @@ import java.util.Optional;
 public interface ShortsRepository extends JpaRepository<Shorts, Long>, ShortsCustomRepository {
     Optional<Slice<Shorts>> findAllByMemberId(Pageable pageable, String memberId);
 
-    Optional<Shorts> findByShortsId(Long shortsId);
+    @Query("""
+                SELECT s.shortsId, s.title, s.memberId, s.placeId, s.travelogueId,
+                       s.shortsVideoUrl, s.thumbnailUrl, s.assignedStatus, s.viewCount,
+                       m.name, m.handle, m.profile
+                FROM Shorts s
+                JOIN Member m ON s.memberId = m.memberId
+                WHERE s.shortsId = :shortsId
+            """)
+    Optional<Object[]> findShortsWithMemberByShortsId(@Param("shortsId") Long shortsId);
 
     @Query("""
             SELECT s

--- a/src/main/java/com/adregamdi/shorts/infrastructure/ShortsRepository.java
+++ b/src/main/java/com/adregamdi/shorts/infrastructure/ShortsRepository.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 public interface ShortsRepository extends JpaRepository<Shorts, Long>, ShortsCustomRepository {
     Optional<Slice<Shorts>> findAllByMemberId(Pageable pageable, String memberId);
 
+    Optional<Shorts> findByShortsId(Long shortsId);
+
     @Query("""
             SELECT s
              FROM Shorts s

--- a/src/main/java/com/adregamdi/shorts/presentation/ShortsController.java
+++ b/src/main/java/com/adregamdi/shorts/presentation/ShortsController.java
@@ -47,6 +47,20 @@ public class ShortsController {
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 
+    @GetMapping
+    @MemberAuthorize
+    public ResponseEntity<ApiResponse<GetShortsByShortsIdResponse>> getShortsByShortsId(
+            @AuthenticationPrincipal final UserDetails userDetails,
+            @RequestParam(value = "shorts_id") @Positive final Long shortsId
+    ) {
+        GetShortsByShortsIdResponse response = shortsService.getShortsByShortsId(userDetails.getUsername(), shortsId);
+        return ResponseEntity.ok()
+                .body(ApiResponse.<GetShortsByShortsIdResponse>builder()
+                        .statusCode(HttpStatus.OK.value())
+                        .data(response)
+                        .build());
+    }
+
     @GetMapping("/list")
     @MemberAuthorize
     public ResponseEntity<ApiResponse<GetShortsResponse>> getShorts(


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #225 
## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
특정 쇼츠 조회 API 구현
- 회원 서비스와 쇼츠 서비스는 서로 필요한 메서드가 있어서 서로를 참조했는데 이때 참조 순환이 발생했다.
그래서 쇼츠 조회 쿼리문에서 회원 테이블을 조인하여 필요한 데이터를 조회하고
회원 서비스를 참조하지 않는 방법으로 해결했다.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
```
{
    "status_code": 200,
    "data": {
        "shorts": {
            "shorts_id": 1,
            "title": null,
            "member_id": "13ff8e4d-9877-4371-82e5-a20a6e4c7197",
            "name": "조만제",
            "handle": "whakswp123-zzzzz",
            "profile": "https://adregamdi-dev2.s3.ap-northeast-2.amazonaws.com/profile/default_profile_image.png",
            "place_id": null,
            "place_title": "",
            "place_image": "",
            "travelogue_id": null,
            "travelogue_title": null,
            "travelogue_image": "",
            "shorts_video_url": "https://adregamdi-dev2.s3.ap-northeast-2.amazonaws.com/shorts/1b4cc7d5-9550-40c4-aab4-f5a27a685138/hHjnSrUNMHFIPTNif3tpc2_20240922.mp4",
            "thumbnail_url": "https://adregamdi-dev2.s3.ap-northeast-2.amazonaws.com/thumbnails/1b4cc7d5-9550-40c4-aab4-f5a27a685138/dPgJTtCVyTp0JDePSByMZT_20240922.png",
            "view_count": 0,
            "like_count": 0,
            "is_liked": false
        }
    }
}
```