### PR TITLE
BugFix - 알림 조회 시 첫 페이지 데이터만 조회되던 버그 수정

### DIFF
--- a/src/main/java/com/adregamdi/notification/application/NotificationServiceImpl.java
+++ b/src/main/java/com/adregamdi/notification/application/NotificationServiceImpl.java
@@ -3,6 +3,7 @@ package com.adregamdi.notification.application;
 import com.adregamdi.core.constant.ContentType;
 import com.adregamdi.notification.domain.Notification;
 import com.adregamdi.notification.dto.NotificationDTO;
+import com.adregamdi.notification.dto.NotificationPageResult;
 import com.adregamdi.notification.dto.request.CreateNotificationRequest;
 import com.adregamdi.notification.dto.request.UpdateNotificationRequest;
 import com.adregamdi.notification.dto.response.GetNotificationResponse;
@@ -45,12 +46,20 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     @Transactional(readOnly = true)
     public GetNotificationResponse getMyNotification(final String currentMemberId, final Long lastId) {
-        List<Notification> notifications = notificationRepository.findByMemberId(currentMemberId, LocalDateTime.now().minusDays(31), lastId)
-                .orElseThrow(() -> new NotificationNotFoundException(currentMemberId));
+        NotificationPageResult pageResult = notificationRepository.findByMemberId(
+                currentMemberId,
+                LocalDateTime.now().minusDays(31),
+                lastId
+        );
+
+        List<NotificationDTO> notificationDTOs = pageResult.notifications().stream()
+                .map(NotificationDTO::from)
+                .toList();
 
         return GetNotificationResponse.of(
-                countNoReadNotification(notifications),
-                notifications.stream().map(NotificationDTO::from).toList()
+                countNoReadNotification(pageResult.notifications()),
+                pageResult.hasNext(),
+                notificationDTOs
         );
     }
 

--- a/src/main/java/com/adregamdi/notification/dto/NotificationPageResult.java
+++ b/src/main/java/com/adregamdi/notification/dto/NotificationPageResult.java
@@ -1,0 +1,11 @@
+package com.adregamdi.notification.dto;
+
+import com.adregamdi.notification.domain.Notification;
+
+import java.util.List;
+
+public record NotificationPageResult(
+        boolean hasNext,
+        List<Notification> notifications
+) {
+}

--- a/src/main/java/com/adregamdi/notification/dto/response/GetNotificationResponse.java
+++ b/src/main/java/com/adregamdi/notification/dto/response/GetNotificationResponse.java
@@ -8,11 +8,13 @@ import java.util.List;
 @Builder
 public record GetNotificationResponse(
         int noReadElements,
+        boolean hasNext,
         List<NotificationDTO> notificationList
 ) {
-    public static GetNotificationResponse of(final int noReadElements, final List<NotificationDTO> notificationList) {
+    public static GetNotificationResponse of(final int noReadElements, final boolean hasNext, final List<NotificationDTO> notificationList) {
         return GetNotificationResponse.builder()
                 .noReadElements(noReadElements)
+                .hasNext(hasNext)
                 .notificationList(notificationList)
                 .build();
     }

--- a/src/main/java/com/adregamdi/notification/infrastructure/NotificationCustomRepository.java
+++ b/src/main/java/com/adregamdi/notification/infrastructure/NotificationCustomRepository.java
@@ -1,11 +1,9 @@
 package com.adregamdi.notification.infrastructure;
 
-import com.adregamdi.notification.domain.Notification;
+import com.adregamdi.notification.dto.NotificationPageResult;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 
 public interface NotificationCustomRepository {
-    Optional<List<Notification>> findByMemberId(final String memberId, final LocalDateTime date, final Long lastId);
+    NotificationPageResult findByMemberId(final String memberId, final LocalDateTime date, final Long lastId);
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #235 
## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
알림 조회 api
- 정렬 조건 생성 날짜에서 알림 id로 수정
- 다음 페이지 여부 추가