### PR TITLE
Refactor - 인기 장소 리스트 조회 캐싱 방식으로 수정

### DIFF
--- a/src/main/java/com/adregamdi/core/config/SecurityConfig.java
+++ b/src/main/java/com/adregamdi/core/config/SecurityConfig.java
@@ -5,7 +5,7 @@ import com.adregamdi.core.jwt.service.JwtService;
 import com.adregamdi.core.oauth2.application.CustomOAuth2UserService;
 import com.adregamdi.core.oauth2.handler.OAuth2LoginFailureHandler;
 import com.adregamdi.core.oauth2.handler.OAuth2LoginSuccessHandler;
-import com.adregamdi.core.redis.application.RedisService;
+import com.adregamdi.core.redis.application.TokenRedisService;
 import com.adregamdi.member.infrastructure.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -29,7 +29,7 @@ import java.util.Arrays;
 public class SecurityConfig {
     private final JwtService jwtService;
     private final MemberRepository memberRepository;
-    private final RedisService redisService;
+    private final TokenRedisService redisService;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;

--- a/src/main/java/com/adregamdi/core/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/adregamdi/core/jwt/filter/JwtAuthenticationFilter.java
@@ -3,7 +3,7 @@ package com.adregamdi.core.jwt.filter;
 import com.adregamdi.core.exception.GlobalException;
 import com.adregamdi.core.handler.ErrorResponse;
 import com.adregamdi.core.jwt.service.JwtService;
-import com.adregamdi.core.redis.application.RedisService;
+import com.adregamdi.core.redis.application.TokenRedisService;
 import com.adregamdi.core.utils.PasswordUtil;
 import com.adregamdi.member.domain.Member;
 import com.adregamdi.member.infrastructure.MemberRepository;
@@ -34,7 +34,7 @@ import java.util.Objects;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
     private final JwtService jwtService;
-    private final RedisService redisService;
+    private final TokenRedisService tokenRedisService;
     private final MemberRepository memberRepository;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
     private final List<String> allowedUris;
@@ -91,7 +91,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             final String refreshToken
     ) {
         try {
-            String memberId = redisService.getMemberIdByRefreshToken(refreshToken);
+            String memberId = tokenRedisService.getMemberIdByRefreshToken(refreshToken);
             if (memberId == null) {
                 throw new GlobalException.TokenValidationException("해당 리프레시 토큰을 가진 회원이 없습니다.");
             }
@@ -117,7 +117,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private String reIssueRefreshToken(final String memberId) {
         String reIssuedRefreshToken = jwtService.createRefreshToken();
-        redisService.saveRefreshToken(memberId, reIssuedRefreshToken);
+        tokenRedisService.saveRefreshToken(memberId, reIssuedRefreshToken);
         return reIssuedRefreshToken;
     }
 

--- a/src/main/java/com/adregamdi/core/jwt/service/JwtService.java
+++ b/src/main/java/com/adregamdi/core/jwt/service/JwtService.java
@@ -1,7 +1,7 @@
 package com.adregamdi.core.jwt.service;
 
 import com.adregamdi.core.exception.GlobalException;
-import com.adregamdi.core.redis.application.RedisService;
+import com.adregamdi.core.redis.application.TokenRedisService;
 import com.adregamdi.member.application.MemberService;
 import com.adregamdi.member.domain.Role;
 import com.adregamdi.member.infrastructure.MemberRepository;
@@ -30,7 +30,7 @@ public class JwtService {
     private static final String MEMBER_ID_CLAIM = "memberId";
     private static final String ROLE = "role";
     private static final String BEARER = "Bearer ";
-    private final RedisService redisService;
+    private final TokenRedisService tokenRedisService;
     private final MemberService memberService;
     private final MemberRepository memberRepository;
     @Value("${jwt.secret-key}")
@@ -123,7 +123,7 @@ public class JwtService {
 
     public Optional<String> extractMemberId(final String accessToken) {
         try {
-            if (redisService.isLoggedOutAccessToken(accessToken)) {
+            if (tokenRedisService.isLoggedOutAccessToken(accessToken)) {
                 log.info("로그아웃된 액세스 토큰입니다.");
                 throw new LogoutMemberException();
             }
@@ -205,7 +205,7 @@ public class JwtService {
     }
 
     public void validateRefreshToken(final String memberId, final String refreshToken) {
-        if (!refreshToken.equals(redisService.getRefreshToken(memberId))) {
+        if (!refreshToken.equals(tokenRedisService.getRefreshToken(memberId))) {
             log.info("저장된 리프레시 토큰과 제공된 리프레시 토큰이 일치하지 않습니다. MemberId: {}", memberId);
             throw new GlobalException.RefreshTokenMismatchException();
         }

--- a/src/main/java/com/adregamdi/core/oauth2/application/OAuth2Service.java
+++ b/src/main/java/com/adregamdi/core/oauth2/application/OAuth2Service.java
@@ -4,7 +4,7 @@ import com.adregamdi.core.jwt.service.JwtService;
 import com.adregamdi.core.oauth2.dto.LoginRequest;
 import com.adregamdi.core.oauth2.dto.LoginResponse;
 import com.adregamdi.core.oauth2.dto.OAuth2Attributes;
-import com.adregamdi.core.redis.application.RedisService;
+import com.adregamdi.core.redis.application.TokenRedisService;
 import com.adregamdi.member.domain.Member;
 import com.adregamdi.member.domain.SocialType;
 import com.adregamdi.member.infrastructure.MemberRepository;
@@ -44,7 +44,7 @@ public class OAuth2Service {
     private static final String KAKAO = "kakao";
     private final WebClient webClient;
     private final JwtService jwtService;
-    private final RedisService redisService;
+    private final TokenRedisService tokenRedisService;
     private final MemberRepository memberRepository;
 
     @Value("${social-login.provider.apple.team-id}")
@@ -88,7 +88,7 @@ public class OAuth2Service {
         String refreshToken = jwtService.createRefreshToken();
 
         // Redis에 리프레시 토큰 저장
-        redisService.saveRefreshToken(findMember.getMemberId(), refreshToken);
+        tokenRedisService.saveRefreshToken(findMember.getMemberId(), refreshToken);
 
 //        findMember.updateRefreshToken(refreshToken);
 //        findMember.updateRefreshTokenStatus(true);

--- a/src/main/java/com/adregamdi/core/redis/application/RedisService.java
+++ b/src/main/java/com/adregamdi/core/redis/application/RedisService.java
@@ -19,7 +19,6 @@ import java.util.concurrent.TimeUnit;
 @Service
 @RequiredArgsConstructor
 public class RedisService {
-
     private static final String REFRESH_TOKEN_PREFIX = "RT:";
     private static final String LOGOUT_ACCESS_TOKEN_PREFIX = "LOGOUT:AT:";
     private final RedisTemplate<String, String> redisTemplate;

--- a/src/main/java/com/adregamdi/core/redis/application/TokenRedisService.java
+++ b/src/main/java/com/adregamdi/core/redis/application/TokenRedisService.java
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class RedisService {
+public class TokenRedisService {
     private static final String REFRESH_TOKEN_PREFIX = "RT:";
     private static final String LOGOUT_ACCESS_TOKEN_PREFIX = "LOGOUT:AT:";
     private final RedisTemplate<String, String> redisTemplate;

--- a/src/main/java/com/adregamdi/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/adregamdi/member/application/MemberServiceImpl.java
@@ -1,6 +1,6 @@
 package com.adregamdi.member.application;
 
-import com.adregamdi.core.redis.application.RedisService;
+import com.adregamdi.core.redis.application.TokenRedisService;
 import com.adregamdi.like.application.LikesService;
 import com.adregamdi.media.application.ImageService;
 import com.adregamdi.member.domain.Member;
@@ -38,7 +38,7 @@ import static com.adregamdi.media.domain.ImageTarget.PROFILE;
 public class MemberServiceImpl implements MemberService {
     private final WebClient webClient;
     private final ImageService imageService;
-    private final RedisService redisService;
+    private final TokenRedisService tokenRedisService;
     private final MemberRepository memberRepository;
 
     private final LikesService likesService;
@@ -97,7 +97,7 @@ public class MemberServiceImpl implements MemberService {
 //        member.updateRefreshTokenStatus(false);
 
         // Redis에서 리프레시 토큰 삭제 및 액세스 토큰 로그아웃 처리
-        redisService.logoutUser(memberId, accessToken);
+        tokenRedisService.logoutUser(memberId, accessToken);
     }
 
     /*

--- a/src/main/java/com/adregamdi/place/application/PlaceRedisService.java
+++ b/src/main/java/com/adregamdi/place/application/PlaceRedisService.java
@@ -1,0 +1,71 @@
+package com.adregamdi.place.application;
+
+import com.adregamdi.core.redis.exception.RedisException;
+import com.adregamdi.place.dto.PopularPlaceDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PlaceRedisService {
+    private static final String POPULAR_PLACES_KEY = "popular:places";
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void savePopularPlaces(List<PopularPlaceDTO> popularPlaces) {
+        try {
+            redisTemplate.delete(POPULAR_PLACES_KEY);
+            for (PopularPlaceDTO place : popularPlaces) {
+                redisTemplate.opsForZSet().add(POPULAR_PLACES_KEY,
+                        objectMapper.writeValueAsString(place),
+                        place.place().getAddCount());
+            }
+            redisTemplate.expire(POPULAR_PLACES_KEY, Duration.ofHours(1));
+        } catch (JsonProcessingException e) {
+            log.error("인기 장소 저장 중 JSON 직렬화 오류", e);
+            throw new RedisException.RedisDataSerializationException();
+        } catch (RedisConnectionFailureException e) {
+            log.error("인기 장소 저장 중 Redis 연결 실패", e);
+            throw new RedisException.RedisConnectionFailureException();
+        } catch (Exception e) {
+            log.error("인기 장소 저장 중 예기치 않은 오류", e);
+            throw new RedisException.RedisCommandExecutionException();
+        }
+    }
+
+    public List<PopularPlaceDTO> getPopularPlaces() {
+        try {
+            Set<String> cachedPlaces = redisTemplate.opsForZSet().reverseRange(POPULAR_PLACES_KEY, 0, -1);
+            if (cachedPlaces == null || cachedPlaces.isEmpty()) {
+                return null;
+            }
+            return cachedPlaces.stream()
+                    .map(place -> {
+                        try {
+                            return objectMapper.readValue(place, PopularPlaceDTO.class);
+                        } catch (JsonProcessingException e) {
+                            log.error("인기 장소 역직렬화 중 오류", e);
+                            throw new RedisException.RedisDataSerializationException();
+                        }
+                    })
+                    .collect(Collectors.toList());
+        } catch (RedisConnectionFailureException e) {
+            log.error("인기 장소 조회 중 Redis 연결 실패", e);
+            throw new RedisException.RedisConnectionFailureException();
+        } catch (Exception e) {
+            log.error("인기 장소 조회 중 예기치 않은 오류", e);
+            throw new RedisException.RedisCommandExecutionException();
+        }
+    }
+}

--- a/src/main/java/com/adregamdi/place/application/PlaceServiceImpl.java
+++ b/src/main/java/com/adregamdi/place/application/PlaceServiceImpl.java
@@ -4,6 +4,7 @@ import com.adregamdi.block.domain.Block;
 import com.adregamdi.block.exception.BlockException;
 import com.adregamdi.block.infrastructure.BlockRepository;
 import com.adregamdi.core.constant.ContentType;
+import com.adregamdi.core.redis.application.RedisService;
 import com.adregamdi.like.application.LikesService;
 import com.adregamdi.media.application.ImageService;
 import com.adregamdi.member.domain.Member;
@@ -32,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Slice;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -62,6 +64,7 @@ public class PlaceServiceImpl implements PlaceService {
     private final ObjectMapper objectMapper;
     private final ImageService imageService;
     private final LikesService likesService;
+    private final RedisService redisService;
     private final MemberRepository memberRepository;
     private final PlaceRepository placeRepository;
     private final PlaceReviewRepository placeReviewRepository;
@@ -345,6 +348,10 @@ public class PlaceServiceImpl implements PlaceService {
                 totalPlaces,
                 placeInfos
         );
+    }
+
+    @Scheduled
+    private void savePopularPlaces() {
     }
 
     /*


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #247 
## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
일정에 많이 추가된 장소 조회 api
- 변경 전: 호출마다 DB에서 조회하는 방식
- 변경 후: 주기적으로 DB에서 조회하여 인메모리에 캐싱하고 api 호출 시 캐싱된 데이터 조회
- 기대효과: 디스크가 아닌 메모리를 기반으로 조회하므로 api 응답 시간 감소, DB의 cpu, i/o 사용을 줄여 부하 감소
- 단점: 프론트로 응답되는 데이터가 최신이 아니다, 구현이 상대적으로 복잡하다, 프로젝트 규모를 생각하면 오버스펙일 수 있다

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
